### PR TITLE
Changes visibility of the silicon's binary chat.

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -319,14 +319,17 @@ em {
 }
 
 .binarysay {
-  color: #1e90ff;
+  color: #20c20e;
+  background-color: #000000;
+  display: block;
 }
 
 .binarysay a {
   color: #00ff00;
 }
 
-.binarysay a:active, .binarysay a:visited {
+.binarysay a:active,
+.binarysay a:visited {
   color: #88ff88;
 }
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Takes the silicon's binary chat from the light mode and replaces the dark mode chat with the one in light mode.
(Will IN THEORY work, maybe wont(probably wont(this isnt gonna work is it(nope))))
This idea came from this pull request from TG: https://github.com/tgstation/tgstation/pull/33222
(Picture is from their pull request(in theory it should look like this while on dark mode instead of only light mode))
![image](https://user-images.githubusercontent.com/89947174/148663228-6384dada-318b-4f8e-962f-4dd6a1fb93ee.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I dunno it just makes it more visible.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Makes the silicon chat more visible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
