### PR TITLE
Adds atmos to Remora's toxin shuttle

### DIFF
--- a/_maps/map_files/RemoraStation/RemoraStation.dmm
+++ b/_maps/map_files/RemoraStation/RemoraStation.dmm
@@ -1067,6 +1067,14 @@
 	dir = 1
 	},
 /area/chapel)
+"akh" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "akn" = (
 /obj/machinery/door/window/northright{
 	name = "Library Desk Door";
@@ -3694,6 +3702,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"bhk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "bhm" = (
 /obj/structure/closet,
 /obj/item/clothing/under/rank/engineering/void,
@@ -5859,6 +5879,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/mixing)
+"dkB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium,
+/area/science/mixing)
 "dkI" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/structure/cable,
@@ -7389,6 +7415,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"exF" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "exW" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain/private)
@@ -8487,6 +8519,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"frS" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "fsz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -11762,6 +11801,14 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine/atmos)
+"ill" = (
+/obj/machinery/camera{
+	c_tag = "Science Toxins Test";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "iln" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -17773,6 +17820,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"nGl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "nHa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -25018,15 +25074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security)
-"tJr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
-/turf/open/floor/mineral/titanium,
-/area/science/mixing)
 "tJu" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room";
@@ -26714,6 +26761,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"vfr" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "vfy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -29607,6 +29660,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"xAY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "xBl" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/conveyor/inverted{
@@ -29797,6 +29856,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"xKg" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/science/mixing)
 "xKS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -29866,12 +29931,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xNr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium,
-/area/science/mixing)
 "xND" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -29929,13 +29988,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"xQQ" = (
-/obj/machinery/camera{
-	c_tag = "Science Toxins Test";
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium,
-/area/science/mixing)
 "xQR" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -48917,7 +48969,7 @@ hnb
 reL
 reL
 reL
-aaa
+reL
 aaa
 aaa
 aaa
@@ -49170,10 +49222,10 @@ aaa
 xIt
 xjh
 reL
-tJr
-xQQ
-ksT
-reL
+bhk
+ill
+vfr
+xKg
 reL
 reL
 aaa
@@ -49427,7 +49479,7 @@ aaa
 reL
 reL
 reL
-tTW
+frS
 ksT
 ksT
 sAo
@@ -49944,7 +49996,7 @@ reL
 tTW
 ksT
 ksT
-fNK
+ksT
 dkp
 reL
 reL
@@ -50198,10 +50250,10 @@ aaa
 xIt
 xjh
 reL
-xNr
-ksT
-ksT
-reL
+nGl
+akh
+xAY
+fNK
 reL
 reL
 aaa
@@ -50457,9 +50509,9 @@ reL
 reL
 rja
 reL
+dkB
 reL
 reL
-aaa
 aaa
 aaa
 aaa
@@ -50714,7 +50766,7 @@ reL
 reL
 reL
 reL
-aaa
+exF
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds some basic atmospherics to the toxin launching shuttle on Remora Station.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

So the shuttle can regain atmospherics.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added atmospherics to Remora's toxin shuttle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
