### PR TITLE
Gives the AI a shell from roundstart.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -378,20 +378,42 @@ SUBSYSTEM_DEF(ticker)
 			SSticker.minds += P.new_character.mind
 		CHECK_TICK
 
-
+/**
+  * Equips people that are readied up when the round starts
+  *
+  * In addition, responsible for spawning the cyborg shell if there are no roundstart cyborgs and announcing if there ISN'T a Captain present
+  */
 /datum/controller/subsystem/ticker/proc/equip_characters()
-	var/captainless=1
+	var/captainless = TRUE
+	var/no_cyborgs = TRUE
+
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/N = i
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)
 			if(player.mind.assigned_role == "Captain")
-				captainless=0
+				captainless = FALSE
+			if(player.mind.assigned_role == "Cyborg")
+				no_cyborgs = FALSE
 			if(player.mind.assigned_role != player.mind.special_role)
-				SSjob.EquipRank(N, player.mind.assigned_role, 0)
+				SSjob.EquipRank(N, player.mind.assigned_role, FALSE)
 				if(CONFIG_GET(flag/roundstart_traits) && ishuman(N.new_character))
 					SSquirks.AssignQuirks(N.new_character, N.client, TRUE)
 		CHECK_TICK
+	if(no_cyborgs)
+		var/obj/S = null
+		for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
+			if(sloc.name != "Cyborg")
+				S = sloc //so we can revert to spawning them on top of eachother if something goes wrong
+				continue
+			if(locate(/mob/living) in sloc.loc)
+				continue
+			S = sloc
+			sloc.used = TRUE
+			break
+		if(S)
+			new /mob/living/silicon/robot/shell(get_turf(S))
+
 	if(captainless)
 		for(var/i in GLOB.new_player_list)
 			var/mob/dead/new_player/N = i

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -379,9 +379,8 @@ SUBSYSTEM_DEF(ticker)
 		CHECK_TICK
 
 /**
-  * Equips people that are readied up when the round starts
-  *
-  * In addition, responsible for spawning the cyborg shell if there are no roundstart cyborgs and announcing if there ISN'T a Captain present
+Equips people that are readied up when the round starts
+In addition, responsible for spawning the cyborg shell if there are no roundstart cyborgs and announcing if there ISN'T a Captain present
   */
 /datum/controller/subsystem/ticker/proc/equip_characters()
 	var/captainless = TRUE

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -381,7 +381,7 @@ SUBSYSTEM_DEF(ticker)
 /**
 Equips people that are readied up when the round starts
 In addition, responsible for spawning the cyborg shell if there are no roundstart cyborgs and announcing if there ISN'T a Captain present
-  */
+*/
 /datum/controller/subsystem/ticker/proc/equip_characters()
 	var/captainless = TRUE
 	var/no_cyborgs = TRUE

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -926,15 +926,15 @@
 	toggle_headlamp(FALSE, TRUE)
 
 /**
- * Records an IC event log entry in the cyborg's internal tablet.
- *
- * Creates an entry in the borglog list of the cyborg's internal tablet, listing the current
- * in-game time followed by the message given. These logs can be seen by the cyborg in their
- * BorgUI tablet app. By design, logging fails if the cyborg is dead.
- *
- * Arguments:
- * arg1: a string containing the message to log.
- */
+* Records an IC event log entry in the cyborg's internal tablet.
+*
+* Creates an entry in the borglog list of the cyborg's internal tablet, listing the current
+* in-game time followed by the message given. These logs can be seen by the cyborg in their
+* BorgUI tablet app. By design, logging fails if the cyborg is dead.
+*
+* Arguments:
+* arg1: a string containing the message to log.
+*/
 /mob/living/silicon/robot/proc/logevent(string = "")
 	if(!string)
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -925,7 +925,7 @@
 		lamp_doom = connected_ai.doomsday_device ? TRUE : FALSE
 	toggle_headlamp(FALSE, TRUE)
 
-/**
+/*
 * Records an IC event log entry in the cyborg's internal tablet.
 *
 * Creates an entry in the borglog list of the cyborg's internal tablet, listing the current

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -925,16 +925,6 @@
 		lamp_doom = connected_ai.doomsday_device ? TRUE : FALSE
 	toggle_headlamp(FALSE, TRUE)
 
-/*
-* Records an IC event log entry in the cyborg's internal tablet.
-*
-* Creates an entry in the borglog list of the cyborg's internal tablet, listing the current
-* in-game time followed by the message given. These logs can be seen by the cyborg in their
-* BorgUI tablet app. By design, logging fails if the cyborg is dead.
-*
-* Arguments:
-* arg1: a string containing the message to log.
-*/
 /mob/living/silicon/robot/proc/logevent(string = "")
 	if(!string)
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -949,3 +949,4 @@
 		program.force_full_update()
 /mob/living/silicon/robot/shell
 	shell = TRUE
+

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -947,3 +947,5 @@
 	var/datum/computer_file/program/robotact/program = modularInterface.get_robotact()
 	if(program)
 		program.force_full_update()
+/mob/living/silicon/robot/shell
+	shell = TRUE

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -150,7 +150,7 @@
 
 /mob/living/silicon/robot/shell
 	shell = TRUE
-	cell = null
+	cell = /obj/item/stock_parts/cell/high
 
 /mob/living/silicon/robot/model
 	var/set_model = /obj/item/robot_model


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When someone joins as the AI round start, a shell will be created for them. 
Original PR: https://github.com/yogstation13/Yogstation/pull/10397
Thanks to the head coder for helping my tiny brain fix this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The round is 1 minute in. Over science comms you hear the screaming of a robotic voice, "ROBO MAKE ME A SHELL SO I CAN DO SOMETHING"
This problem is no longer! The ai now has a shell from roundstart
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: AI will have a shell roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
