### PR TITLE
Bloons TD6 in SS13

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -130,6 +130,31 @@
 	force = 0
 	var/random_color = TRUE
 
+/obj/item/toy/balloon/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/ammo_casing/caseless/foam_dart) && ismonkey(user))
+		pop_balloon(monkey_pop = TRUE)
+	else
+		return ..()
+
+/obj/item/toy/balloon/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	if(ismonkey(throwingdatum.thrower) && istype(AM, /obj/item/ammo_casing/caseless/foam_dart))
+		pop_balloon(monkey_pop = TRUE)
+	else
+		return ..()
+
+/obj/item/toy/balloon/bullet_act(obj/projectile/P)
+	if((istype(P,/obj/projectile/bullet/p50) || istype(P,/obj/projectile/bullet/reusable/foam_dart)) && ismonkey(P.firer))
+		pop_balloon(monkey_pop = TRUE)
+	else
+		return ..()
+
+
+/obj/item/toy/balloon/proc/pop_balloon(monkey_pop = FALSE)
+	playsound(src, 'sound/effects/cartoon_pop.ogg', 50, vary = TRUE)
+	if(monkey_pop) // Monkeys make money from popping bloons
+		new /obj/item/coin/iron(get_turf(src))
+	qdel(src)
+
 /obj/item/toy/balloon/Initialize(mapload)
 	. = ..()
 	if(random_color)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

(PORT OF TG #64389)
Lets monkeys pop balloons with foam darts. Bloons drop iron coins when popped this way.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![150849388-1b2ffcec-2f44-4494-b1bb-aff91b65412b](https://user-images.githubusercontent.com/89947174/151410561-85457dbd-2ad9-4a59-b7a5-915769ed0cd6.gif)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Monkeys can pop bloons and drop money from popping them. Now you can play bloons TD6 in ss13!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
