### PR TITLE
a simulation, INSIDE, of a simulation! NTSL updates

### DIFF
--- a/ModularBungalow/NTSL/code/modules/scripting/Implementations/Telecomms.dm
+++ b/ModularBungalow/NTSL/code/modules/scripting/Implementations/Telecomms.dm
@@ -2,8 +2,9 @@
 
 
 /* --- Traffic Control Scripting Language --- */
-	// Nanotrasen TCS Language - Made by Doohl, ported to Yogs by Altoids, ported to Skyrat by Tf4, and Ported to Bungalow by Kitsunemitsu and repaired by Horologium
+	// Nanotrasen TCS Language - Made by Doohl, ported to Yogs by Altoids, ported to Skyrat by Tf4, and Ported to Bungalow by Kitsunemitsu and updated by Horologium
 
+//These numerics translate to how you want to reference them in-game.
 #define NTSL_LANG_APHASIA 1
 #define NTSL_LANG_BEACHBUM 2
 #define NTSL_LANG_BUZZWORDS 3
@@ -136,9 +137,9 @@
 			return /datum/language/drone
 
 GLOBAL_LIST_INIT(allowed_custom_spans,list(SPAN_ROBOT,SPAN_YELL,SPAN_ITALICS,SPAN_SANS,SPAN_COMMAND,SPAN_CLOWN))//Span classes that players are allowed to set in a radio transmission.
-//Bungalow races (in alphabetical order to languages below: Beepeople, Ethereal, Felinid, Human, Jelly, Lizard, Moth, Plasmaman). Piratespeak is on here for lols and so poly can speak like a proper bird. If you do not want this, remove the last element of the allowed_translations list.
+//Bungalow races (in alphabetical order to languages below: Beepeople, Ethereal, Felinid, Human, Jelly, Lizard, Moth, Plasmaman and Monkey). Piratespeak is on here for lols and so poly can speak like a proper bird. If you do not want this, remove the last element of the allowed_translations list.
 //The original comment saying this part didnt work, wasnt quite right but was on the right track.
-GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/language/voltaic,/datum/language/nekomimetic,/datum/language/common,/datum/language/slime,/datum/language/draconic,/datum/language/moffic,/datum/language/calcic,/datum/language/piratespeak))// language datums that players are allowed to translate to in a radio transmission.
+GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/language/voltaic,/datum/language/nekomimetic,/datum/language/common,/datum/language/slime,/datum/language/draconic,/datum/language/moffic,/datum/language/calcic,/datum/language/monkey,/datum/language/piratespeak))// language datums that players are allowed to translate to in a radio transmission.
 
 /n_Interpreter/TCS_Interpreter
 	var/datum/TCS_Compiler/Compiler
@@ -223,28 +224,7 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/lang
 		"wacky" = SPAN_SANS,
 		"commanding" = SPAN_COMMAND
 	)))
-	//Current allowed span classes
 
-	//Language bitflags
-	/* (Following comment written 26 Jan 2019)
-	So, language doesn't work with bitflags anymore
-	But having them be bitflags inside of NTSL makes more sense in its context
-	So, when we get the signal back from NTSL, if the language has been altered, we'll set it to a new language datum,
-	based on the bitflag the guy used.
-
-	However, I think the signal can only have one language
-	So, the lowest bit set within $language overrides any higher ones that are set.
-	*/
-	/*
-	interpreter.SetVar("languages", new /datum/n_enum(list(
-		"human" = HUMAN,
-		"monkey" = MONKEY,
-		"robot" = ROBOT,
-		"polysmorph" = POLYSMORPH,
-		"draconic" = DRACONIC,
-		"beachtounge" = BEACHTONGUE
-	)))
-	*/
 
 	interpreter.Run() // run the thing
 
@@ -300,14 +280,13 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/lang
 
 	// Backwards-apply variables onto signal data
 	/* sanitize EVERYTHING. fucking players can't be trusted with SHIT */
-
+	//Horologium: i am moving these blocks closer together to remind other that they are in the same method
 	var/msg = script_signal.get_clean_property("content", signal.data["message"])
 	if(isnum(msg))
 		msg = "[msg]"
 	else if(!msg)
 		msg = "*beep*"
 	signal.data["message"] = msg
-
 
 	signal.frequency = script_signal.get_clean_property("freq", signal.frequency)
 
@@ -375,13 +354,15 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/lang
 		S.properties["source"] = params[3]
 	if(params.len >= 4)
 		S.properties["job"] = params[4]
+	if(params.len >= 5)
+		S.properties["language"] = params[5]
 	return S
 
 
 /* -- Actual language proc code -- */
 
 #define SIGNAL_COOLDOWN 20 // 2 seconds
-#define MAX_MEM_VARS 500 // The maximum number of variables that can be stored by NTSL via mem()
+#define MAX_MEM_VARS 400 // The maximum number of variables that can be stored by NTSL via mem(). Decreased from 500 to 400 because my goodness anything to let this run faster.
 
 /datum/n_function/default/mem
 	name = "mem"
@@ -449,6 +430,7 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/lang
 
 		message_admins("Telecomms server \"[S.id]\" sent a signal command, which was triggered by NTSL<B>: </B> [format_frequency(freq)]/[code]")
 
+//Determines the broadcast function, give it a FULLY AND PROPERLY FORMATTED SIGNAL OBJECT to watch the magic happen. Does nothing otherwise - 'bad-code-safe'. - Horologium
 /datum/n_function/default/broadcast
 	name = "broadcast"
 	interp_type = /n_Interpreter/TCS_Interpreter
@@ -542,3 +524,55 @@ GLOBAL_LIST_INIT(allowed_translations,list(/datum/language/buzzwords,/datum/lang
 	return pass // Returns, as of Jan 23 2019, the number of machines that received this broadcast's message.
 #undef SIGNAL_COOLDOWN
 #undef MAX_MEM_VARS
+
+/* I KNOW NTSL - I CAN DO ANYTHING
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWNKKKKKNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWNNN0:.....cKNWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWWWWNNWWMMMMMMWWO;...       .c0WWMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWk;,,,,:0WMMMWWk;.             .c0WMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWx;,,,,,,,,:OWk:;.                 'c0MMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNx:,';cccccc;';:.                      'cOWMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNxc,';ccccccccc:.                          oWMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMXx:. .'lkl,,:cccc:.                          'lOWMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMXxl:,. 'cOW0l;,,:cc:.                            cNMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMM0c:ll:c0MMMMMx. .,,'.                            'd0WMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMW0cc0WMMMMXOc. .............              .,,'. .'cx0NMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMN0OO0NMX0l...,okkkkkkkkdoll:'.         .,oOXXo':dl;lXMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO,..'d0c.'clldkOOOOOOOOc..ldxd,.     .'oo'.kMWXd,lKNWMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO. ';....;xl..lxkOOOkxx;   .lxxo'   .oxkd..xMMMNXNWMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO. ,:. ,oxxc. ..lkkkc..     .'ox;   'xkko'.kMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO'.,:. ;kl'.    .'lk;.   .coooxkdl' .c:',d0NMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMNOd,.  ;kxl, .;lllxkdol' .dOOx:'lk;  .  .OMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNOo. ;ko,,:lkOOOOOOOOdl:,'',:ldk;     .OMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMX; ;ko,cOkc:dOOkl;;l0o.  .lkl,.   .cxXMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWklc;cdk0d. .:xO:  .;,  'cdk,   .cxNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMNkoooc;;:lkx:'. 'c.    .':xkl;.   .coooodKMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMNko:,,;oOc .;lxx:'''''''':odl;. .,;,.  .,,;lxKMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO..;lllxOc  .;cllccccccccldo;'',cdOKo..:llc::kWMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMN0OOOOOOOKWMMMMWKOOOXWN0l.     ,l, 'kk:''.. .....;oddddo' ,d:  .,,:OWWMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMNKx,.......:OXWWXk:...lNk.           .dxxxxo' 'cloo:.           .o0XNWMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMO'.,:::::::,.:Ok;.,;. cNk.             ....                       ,0MMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMO'.;:ccccccc:,'';:c:. cN0c.            .''                        .xNWMMMWNNXNXXXNNNNNXXXXXXNWMMM
+MMMNKx,.;c:ccccc:;;ccc:. :Xx.         .,;;,.                          .,OMMWx'.''''''''''''''..;0MMM
+MMMMMN0x;...,:cccccc:..  .'.        .,:ccc:;'                          .xMMWo .',,,,,,,,,,,,,. .kMMM
+MMMMMMMW0xxx:........               .ccc;....    .''.                  .xMMWo  ......;c,...... .kMMM
+MMMMMMMMMMMMKxddddc.            ... .ccc:,.      .:c:,.                 'cOWKxddddc. ':. 'oddddxXMMM
+MMMMMMMMMMMMMMMMMMNkool.     .:ll:. .ccccc:,.    .:ccc:'.                 oWMMMMMM0, ':. :NMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMWOlllllxXWKx:..',ccc:,.    .:ccccc:'.               'lOWMMMM0, ':. cNMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWKkc..''''....  ..';ccccc:. ..             'oONMMK, ':. cNMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWKx;    .','.    .',,,,'  .'.    ..    .;;;dNNOo,.;c. :NMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWo             .'.            .;;.   ;xkkkko'.;c;,,,dNMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWk,.           ;Kx.     ......',,...........;::;,,xNWMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWNx,.         :Xk.     :kKNNNk;',,,;,,,;,,;;;',xNWMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWXx.        :Xk.      .lKNWWXO;...........,xXWMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWNNNNNNNNNk'.':lo'  :Xk..coc;. .'lKNNX0OOOOO00KK0KKWMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMWKl,,,,,,,,,;codxkx;  :Xk..lkxxolll:,,,,,,,,,,dNWMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMKc;clllolloooc,......  :Xk. ........;lllolloool:;dNMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO..o000000000o.        :Xk.         ,k00000000O: ;XMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMO. .,,,;;,,;;:looooooodOWXxooool.   .,;;,;;,;;;coONMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMXxlllllllllllxXMMMMMMMMMMMMMMMMWOllllllllllllloOWMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM*/


### PR DESCRIPTION
## About The Pull Request

This PR attempts to complete the following goals: 
1. Fix the `broadcast` system (script-side) to actually function as intended.
2. Allow NTSL code blocks using process_signal() to optionally return two signal objects.
3. Added an optional argument to the signal constructor.
(Also I forgot to add 'monkey' to the language list in #527 , added it here. ooh ooh ah ah.)



**For point 1:** The broadcast function just was not working. It now is, you must create the signal object as its own variable in-script first. The broadcast function already was 'implemented', the function was designed to send a message but with control over the properties of the message from NTSL.
Example:
```
...
newsignal = signal("My legs have atrophied", 1355, "Aemil Ferrilinea", "Bartender");
broadcast(newsignal);
...
```
Note that the signal object has not fundamentally changed. Inputting invalid information will cause the broadcast to fail. Also, the broadcast will only be emitted when the code is returned (if you return newsignal) meaning it still follows telecommunication protocols. This includes loggings. I am not 100% certain but I believe that instantiating in the method call is a limitation of DM and indirectly the code behind NTSL.

**For point 2:** This was a limitation on how NTSL itself was coded. In the 'newer' revisions, you need to use process_signal to run your code. You currently cannot work around this at all, the code _will not compile in-game_ if you do not code in this method. This means older structures involving multiple method calls do not work. Another restriction in place (that is not changed) is that this method only returns a signal object (changed in this PR). 

What this PR does is allow the user to return up to two signal objects contained in a _list_. 
Example:
`return list(signalA,signalB);`

You can still call a return through `return signal;`, or even have a 1-element list such as `return list(signalA);`. The interpreter has been recoded to properly iterate through this list. **It is very important that I add: the interpreters eval of the list will only allow a maximum number of iterations equal to 2 (even if the list had more elements when returned). This is a hard value, meaning it can only be changed through the source code. All NTSL code still follows the same input sanitization processes as before.**

**Point 3:** Signal object construction. This object, for some reason, was missing the 'language' property. It does get added later in runtime, but I decided to add it in at initialization because that sounds better in my mind.


## Why It's Good For The Game

TG bad
ok now that's out of the way, this update to comms would be good as I am trying to restore health to one of the segments of TG code I feel is very injured at the moment. This will also help NTSL be a bit more flexible in how you can approach it.

The telecomms role(s) feel a bit like they are somewhat useless, and what they primarily do ends up just being messing with other people. Me and the other 3 NTSL coders would like to see an expansion to this role. Not necessarily adding a lot of busywork for these workers but allowing their job to actually interact with the station more than just 'fuck up general comms', "reconnect broken servers" and "telling the captain that the isometric distortion is the reason that the servers are down". This is a good step in that direction.



## Changelog
:cl:
add: Added a new method for code blocks to return two values.
add: Added more comments <3
tweak: tweaked how broadcast works.
removed: removed a commented part of the code floating around. It had been this way since TG afaik, definitely still works without it.
add: Added a new language argument to the constructor of the 'signal' object. 
server: alters NTSL code that is not part of the maps.
/:cl: