### PR TITLE
Updating Fermistation part 8 Engineering rework

### DIFF
--- a/_maps/map_files/Fermistation/Fermistation.dmm
+++ b/_maps/map_files/Fermistation/Fermistation.dmm
@@ -72,6 +72,15 @@
 "abE" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"abI" = (
+/obj/item/toy/cards/deck,
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigpack_candy,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/maintenance/port/aft)
 "aci" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -136,25 +145,15 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/janitor)
 "adb" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "adj" = (
-/obj/item/geiger_counter,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "adw" = (
 /obj/structure/chair/sofa/corp/left,
@@ -248,20 +247,18 @@
 "afk" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/powered)
-"afq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
 "afr" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/glass/reinforced,
 /area/security/prison/rec)
+"afL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "afZ" = (
 /turf/open/floor/glass/reinforced,
 /area/security/prison/rec)
@@ -285,6 +282,13 @@
 	dir = 8
 	},
 /area/hallway/primary/central)
+"agB" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/mmi,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "agH" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -347,6 +351,7 @@
 /obj/structure/sign/poster/ripped{
 	pixel_y = -32
 	},
+/obj/item/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "aim" = (
@@ -398,6 +403,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"ajx" = (
+/obj/structure/festivus{
+	anchored = 1;
+	layer = 4;
+	name = "pole"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "ajy" = (
 /obj/machinery/computer/telecomms/traffic,
 /obj/effect/turf_decal/tile/neutral{
@@ -422,12 +435,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"aka" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
 "akb" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland1";
@@ -518,12 +525,10 @@
 /turf/open/floor/glass/reinforced,
 /area/security/prison/rec)
 "ala" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ald" = (
 /obj/structure/chair{
 	dir = 1
@@ -548,6 +553,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"alG" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "alN" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood{
@@ -563,13 +575,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "amb" = (
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -640,6 +652,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"aql" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/space/nearstation)
 "aqv" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/dark,
@@ -671,6 +688,13 @@
 /obj/machinery/vending/cola/blue,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
+"aqF" = (
+/obj/structure/cable,
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aqO" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
@@ -716,10 +740,9 @@
 /turf/open/floor/glass/reinforced,
 /area/security/prison/rec)
 "arj" = (
-/turf/open/floor/plasteel/airless{
-	icon_state = "damaged5"
-	},
-/area/space/nearstation)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/carpet,
+/area/maintenance/port/aft)
 "arq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -789,6 +812,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"arJ" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "arU" = (
 /obj/structure/statue/bronze/marx{
 	pixel_y = 16
@@ -800,12 +827,6 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
-"asm" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "asn" = (
 /obj/item/storage/bag/trash,
 /obj/item/mop,
@@ -862,10 +883,11 @@
 	},
 /area/quartermaster/office)
 "asY" = (
-/obj/effect/spawner/lootdrop/prison_contraband,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/closet/crate/trashcart/filled,
+/obj/item/toy/plush/awakenedplushie,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "ati" = (
@@ -878,6 +900,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
+"atm" = (
+/obj/structure/window/spawner,
+/turf/open/space/basic,
+/area/maintenance/port/aft)
 "atx" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -904,6 +930,7 @@
 /obj/item/grown/bananapeel,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aua" = (
@@ -961,16 +988,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"avg" = (
-/obj/item/hatchet/wooden,
-/turf/open/floor/plating/asteroid,
-/area/ruin/has_grav)
 "avk" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/clothing/glasses/sunglasses,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/machinery/power/emitter,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "avH" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/freezer,
@@ -1054,6 +1076,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"awX" = (
+/obj/structure/sign/painting/library_private{
+	pixel_y = 32
+	},
+/obj/machinery/photocopier,
+/obj/item/storage/photo_album/library,
+/turf/open/floor/plasteel/cult,
+/area/library)
 "axh" = (
 /obj/machinery/plate_press,
 /obj/machinery/firealarm{
@@ -1111,11 +1141,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "azw" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Library Desk";
-	req_access_txt = "37"
-	},
+/obj/structure/table/wood,
+/obj/item/toy/toy_xeno,
 /turf/open/floor/carpet,
 /area/library)
 "azC" = (
@@ -1136,6 +1163,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"azZ" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall,
+/area/crew_quarters/bar)
 "aAt" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -1155,30 +1186,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aAN" = (
-/obj/machinery/power/emitter/welded,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "aAT" = (
 /obj/machinery/door/airlock/external/glass,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"aAV" = (
-/obj/item/stack/spacecash/c1{
-	pixel_x = 14;
-	pixel_y = 4
-	},
-/obj/item/stack/spacecash/c1{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/item/stack/spacecash/c1{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
 "aAX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1299,20 +1310,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/bridge)
-"aCF" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "aCR" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -1406,6 +1403,9 @@
 "aEE" = (
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
+"aEI" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "aFb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -1512,14 +1512,12 @@
 	},
 /area/medical/medbay/lobby)
 "aHh" = (
-/obj/structure/table/wood,
-/obj/item/toy/clockwork_watch,
-/obj/item/toy/plush/ratplush,
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/cult,
-/area/library)
+/obj/structure/cable,
+/obj/structure/moisture_trap,
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aHE" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -1548,8 +1546,11 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "aHU" = (
-/obj/machinery/computer/atmos_alert,
 /obj/structure/cable,
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIj" = (
@@ -1615,27 +1616,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aIK" = (
-/obj/machinery/camera/motion{
-	c_tag = "Gravity Generator External Hull South"
-	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/engine/engine_room)
 "aIM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/stairs,
 /area/crew_quarters/office/secretary)
 "aIN" = (
-/obj/item/stack/sheet/plasteel/twenty{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/rods/fifty,
-/obj/item/clothing/gloves/color/yellow,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -1650,6 +1639,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/janitorialcart,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "aJl" = (
@@ -1659,8 +1649,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aJp" = (
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "aJI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
@@ -1701,6 +1699,11 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"aLw" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/plasteel/solarpanel,
+/area/maintenance/solars/port/aft)
 "aLS" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/structure/sign/poster/official/random{
@@ -1817,6 +1820,12 @@
 /obj/machinery/xenoarch/researcher,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"aNt" = (
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "aNv" = (
 /obj/item/clothing/under/color/random{
 	pixel_x = -4;
@@ -1863,22 +1872,31 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
 "aOl" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "aOU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 8
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"aOX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "aPt" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -1927,12 +1945,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"aQo" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "aQq" = (
 /obj/effect/decal/cleanable/crayon,
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"aQs" = (
+/obj/item/airlock_painter,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "aQy" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
@@ -1951,12 +1980,24 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "aRq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"aRu" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"aRD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "aRH" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -2069,6 +2110,7 @@
 	},
 /area/medical/medbay/lobby)
 "aSU" = (
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plating,
 /area/security/prison/work)
 "aTa" = (
@@ -2099,6 +2141,12 @@
 /mob/living/simple_animal/mouse/brown/tom,
 /turf/open/floor/plating,
 /area/security/prison/work)
+"aTr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "aTN" = (
 /obj/item/storage/toolbox/emergency/old,
 /obj/structure/table,
@@ -2169,6 +2217,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
+"aUM" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "aUQ" = (
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -2215,7 +2268,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/plasteel/white/corner,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "aVe" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
@@ -2293,6 +2346,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/item/chisel,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aXh" = (
@@ -2337,8 +2391,10 @@
 /area/security/courtroom)
 "aYc" = (
 /obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aYd" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -2490,7 +2546,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white/side,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "bbB" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -2504,16 +2560,22 @@
 	},
 /turf/closed/wall,
 /area/hallway/primary/central)
+"bch" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bck" = (
 /obj/machinery/vending/cart{
 	req_access_txt = "57"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"bcq" = (
-/obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "bdd" = (
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/tile/brown{
@@ -2538,6 +2600,10 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/clothing/head/collectable/wizard,
 /obj/structure/table/glass,
+/obj/machinery/camera{
+	c_tag = "Aft Port Solar Control";
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
 "bdA" = (
@@ -2562,11 +2628,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/service)
 "bel" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "beq" = (
 /obj/structure/window/spawner,
 /obj/structure/grille,
@@ -2642,6 +2708,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
+"bgG" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Supermatter Chamber";
+	dir = 4;
+	network = list("engine")
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"bgN" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Void Technician's Office";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bgX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -2721,8 +2808,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bin" = (
+/obj/item/stack/rods/twentyfive,
+/turf/open/space/basic,
+/area/space)
 "biH" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/food/branrequests{
@@ -2833,7 +2927,12 @@
 /area/space/nearstation)
 "bla" = (
 /obj/structure/cable,
-/obj/item/bot_assembly/firebot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "blo" = (
@@ -2955,6 +3054,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/service)
 "bnU" = (
@@ -3026,6 +3126,11 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
+"bpa" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil,
+/turf/open/space/basic,
+/area/maintenance/solars/port/aft)
 "bpc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -3098,6 +3203,11 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/plasteel/white,
 /area/security/prison/mess)
+"bqJ" = (
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/maintenance/port/aft)
 "bqN" = (
 /obj/machinery/door/airlock/glass_large,
 /obj/effect/turf_decal/tile/neutral{
@@ -3459,6 +3569,15 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/lab)
+"bxl" = (
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = 28
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "bxm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -3478,9 +3597,15 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
 "bxr" = (
-/obj/item/crowbar/large,
-/turf/open/floor/plasteel/sepia,
-/area/ruin/has_grav)
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bxV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/food/meat/slab/meatproduct,
@@ -3505,9 +3630,16 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "byd" = (
-/obj/machinery/bookbinder,
+/obj/structure/cable,
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/carpet,
-/area/library)
+/area/security/main)
 "bys" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -3516,10 +3648,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "byC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cult,
+/obj/machinery/light/small,
+/obj/structure/table/wood,
+/obj/item/toy/clockwork_watch,
+/turf/open/floor/wood,
 /area/library)
 "bzj" = (
 /obj/structure/table,
@@ -3532,6 +3664,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"bzM" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "bzR" = (
 /obj/effect/decal/cleanable/glitter/pink{
 	layer = 5
@@ -3571,13 +3709,19 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison/mess)
 "bAj" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/storage/bag/construction,
+/obj/item/storage/bag/construction{
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bAl" = (
@@ -3647,6 +3791,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"bCt" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "bCw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -3701,8 +3850,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bDW" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/asteroid,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bDX" = (
 /obj/structure/rack,
@@ -3773,6 +3922,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bEZ" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "bFc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3785,6 +3941,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"bFn" = (
+/obj/structure/particle_accelerator/fuel_chamber{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "bFo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -3886,10 +4049,8 @@
 /turf/open/floor/plating,
 /area/security/prison/work)
 "bGX" = (
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "bHx" = (
 /turf/open/floor/plating,
@@ -3991,6 +4152,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bJr" = (
@@ -4091,15 +4256,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"bLC" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bMh" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
@@ -4162,20 +4318,29 @@
 /obj/item/binoculars,
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/aft)
+"bNB" = (
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "bNQ" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bOC" = (
 /turf/closed/wall/r_wall,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
+"bOD" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "bOV" = (
 /obj/machinery/light{
 	dir = 8
@@ -4191,12 +4356,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
-"bPv" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/space/nearstation)
+/area/security/checkpoint/customs)
 "bPz" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4463,9 +4623,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "bTD" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/field/generator,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
 /area/engine/engineering)
 "bTN" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -4527,9 +4691,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bVA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment{
@@ -4559,10 +4720,6 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
-"bWe" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "bWl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -4614,6 +4771,9 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
+/area/science/research)
+"bWF" = (
+/turf/closed/mineral/random/stationside/asteroid,
 /area/maintenance/port/aft)
 "bWH" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -4693,13 +4853,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bYs" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYC" = (
 /obj/machinery/door/airlock/external{
@@ -4749,12 +4910,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "cac" = (
-/obj/machinery/power/solar_control{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "cau" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white/side{
@@ -4806,8 +4970,18 @@
 "caY" = (
 /obj/structure/chair/stool/bar,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
+"cbi" = (
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"cbl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "cbw" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -4849,9 +5023,14 @@
 /turf/open/floor/glass/reinforced,
 /area/engine/break_room)
 "ccc" = (
-/obj/effect/spawner/lootdrop/food_packaging,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port)
 "ccH" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/ten_k{
@@ -4921,18 +5100,11 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
-"cdB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cem" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/space/basic,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ceo" = (
 /obj/machinery/recharger,
@@ -4995,6 +5167,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"cfF" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/space/nearstation)
 "cfL" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot_white,
@@ -5022,11 +5199,10 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cgf" = (
-/obj/structure/lattice,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cgy" = (
 /turf/open/floor/plasteel/white/side{
@@ -5077,25 +5253,20 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/kitchen_coldroom/freezerfloor,
 /area/crew_quarters/kitchen)
-"chw" = (
-/obj/structure/particle_accelerator/particle_emitter/center{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "chy" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "chM" = (
-/obj/machinery/smartfridge/drinks{
-	icon_state = "boozeomat"
-	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/machinery/the_singularitygen/tesla,
+/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "chW" = (
 /obj/structure/table,
 /obj/item/toner,
@@ -5117,10 +5288,6 @@
 	dir = 6
 	},
 /area/hallway/primary/central)
-"cig" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "cim" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -5137,10 +5304,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ciN" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/carpet/stellar,
 /area/crew_quarters/heads/hop)
 "ciU" = (
@@ -5239,6 +5406,11 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/construction/mining/aux_base)
+"clS" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "clT" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -5401,7 +5573,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "cou" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -5430,6 +5602,16 @@
 	},
 /turf/open/floor/plating,
 /area/space)
+"coT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "coX" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple,
@@ -5465,6 +5647,10 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"cpo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cpr" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -5519,14 +5705,18 @@
 /obj/item/restraints/handcuffs{
 	pixel_y = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "cqu" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -5576,6 +5766,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
+"crT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "crX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5595,6 +5791,7 @@
 "csk" = (
 /obj/structure/closet/emcloset,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "csx" = (
@@ -5825,17 +6022,21 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "cwX" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/space/nearstation)
+/obj/machinery/power/tesla_coil,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "cxj" = (
 /obj/structure/showcase/mecha/ripley,
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
+"cxk" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating/rust,
+/area/ruin/has_grav)
 "cxl" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -5853,10 +6054,9 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cxH" = (
-/obj/structure/lattice,
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/solar/port/aft)
+/obj/item/clothing/head/bearpelt,
+/turf/open/floor/carpet/red,
+/area/crew_quarters/dorms)
 "cxL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -5941,14 +6141,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "czL" = (
-/obj/item/clothing/head/beret/atmos,
-/obj/item/clothing/head/beret/atmos{
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/table,
+/obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "czP" = (
@@ -5980,19 +6176,12 @@
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
 "cBf" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/area/space/nearstation)
-"cBs" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "cBL" = (
 /obj/structure/table/wood,
 /obj/item/toy/foamblade,
@@ -6139,10 +6328,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"cDL" = (
-/obj/structure/bookcase,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "cDN" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
@@ -6180,9 +6365,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "cEY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -6375,6 +6557,12 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/science/mixing)
+"cIJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cIV" = (
 /obj/structure/closet,
 /obj/item/toy/sprayoncan,
@@ -6500,10 +6688,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cLp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/port/fore)
 "cLA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -6590,6 +6778,8 @@
 	req_access_txt = "31"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "cNE" = (
@@ -6757,13 +6947,13 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "cQj" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cQv" = (
@@ -6785,10 +6975,10 @@
 /turf/open/floor/plastic,
 /area/medical/surgery)
 "cQB" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cQC" = (
@@ -6814,9 +7004,8 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cRw" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/item/stack/sticky_tape,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "cRV" = (
 /obj/effect/turf_decal/stripes/line,
@@ -6842,13 +7031,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
 "cSr" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/cult,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/wood,
 /area/library)
 "cSu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -6937,6 +7126,13 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/fore)
+"cTG" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cTR" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -6951,11 +7147,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cUd" = (
-/obj/structure/particle_accelerator/end_cap{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/reflector/double/anchored{
+	dir = 9
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cUH" = (
 /obj/structure/table/glass,
@@ -7110,6 +7306,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cWJ" = (
@@ -7132,6 +7329,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/warden)
+"cXl" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Chamber"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cXw" = (
 /obj/structure/frame/machine{
 	anchored = 1
@@ -7163,10 +7367,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cYr" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+"cYb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "cYs" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -7177,16 +7389,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"cYB" = (
-/obj/structure/table,
-/obj/item/trash/candle{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "cYK" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/aft)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cZc" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -7298,6 +7507,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"daU" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "daZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -7320,6 +7534,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"dbL" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dbP" = (
 /obj/machinery/door/airlock/grunge,
 /obj/structure/cable,
@@ -7448,13 +7671,9 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison/shower)
 "ddm" = (
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_x = 27;
-	pixel_y = -2
-	},
-/turf/open/floor/wood,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "ddw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -7557,6 +7776,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
+"deL" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/aft)
+"deZ" = (
+/obj/item/clothing/gloves/color/fyellow,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dfa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -7569,10 +7796,11 @@
 	dir = 8
 	},
 /obj/structure/closet,
+/obj/structure/cable,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dfg" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -7596,15 +7824,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dfy" = (
-/turf/open/floor/carpet,
-/area/maintenance/port/aft)
 "dfF" = (
 /obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dfG" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -7625,7 +7850,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dfT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -7672,6 +7897,12 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "dgm" = (
@@ -7732,7 +7963,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dih" = (
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/tile/green,
@@ -7836,6 +8067,12 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"dlz" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "dlS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -7940,6 +8177,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dnQ" = (
+/obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dnU" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
@@ -7947,7 +8188,7 @@
 	safety_mode = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dnX" = (
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/mineral/titanium,
@@ -8046,6 +8287,13 @@
 	dir = 6
 	},
 /area/science/research)
+"dpU" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "dqq" = (
 /obj/structure/toilet{
 	dir = 4
@@ -8249,11 +8497,8 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "dtT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/cult,
+/obj/machinery/bookbinder,
+/turf/open/floor/wood,
 /area/library)
 "dtW" = (
 /obj/structure/spider/stickyweb,
@@ -8321,6 +8566,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
+"dvo" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dvy" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
@@ -8340,6 +8589,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dwA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "dwF" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -8435,6 +8688,11 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
+"dxh" = (
+/obj/machinery/power/grounding_rod,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "dxt" = (
 /obj/structure/closet/crate/bin,
 /obj/item/book/granter/language_book/draconic,
@@ -8569,12 +8827,31 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"dzG" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"dAb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "dAq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
+"dAH" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dAI" = (
 /obj/structure/table,
 /obj/item/poster/random_official,
@@ -8686,6 +8963,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"dCZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dDK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8718,6 +9002,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"dDY" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "dEc" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North"
@@ -8746,15 +9035,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dEJ" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/obj/structure/sign/painting/library_private{
-	pixel_y = 32
-	},
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/cult,
-/area/library)
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/port)
 "dER" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -8777,6 +9062,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"dFl" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/effect/turf_decal/bot,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "dFy" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/cyborg,
@@ -8898,10 +9192,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
 "dHF" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "incinerator mix pump"
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dHH" = (
@@ -8911,11 +9202,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dHM" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access_txt = "37"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/wood,
 /area/library)
 "dHQ" = (
 /obj/structure/filingcabinet/security,
@@ -9014,6 +9304,7 @@
 "dIZ" = (
 /obj/structure/table/wood,
 /obj/item/storage/toolbox/artistic,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/library)
 "dJu" = (
@@ -9027,6 +9318,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"dJN" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "dJS" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -9278,8 +9580,11 @@
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "dPW" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "dQb" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
@@ -9290,13 +9595,6 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel,
 /area/security/prison/mess)
-"dQS" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "dQX" = (
 /obj/structure/table,
 /obj/item/pizzabox{
@@ -9350,6 +9648,12 @@
 	dir = 8
 	},
 /area/science/research)
+"dRK" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "dRN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -9382,6 +9686,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison/mess)
+"dSM" = (
+/obj/item/stack/sheet/metal/five,
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "dTH" = (
 /obj/machinery/vending/coffee,
 /obj/item/radio/intercom{
@@ -9409,6 +9717,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"dUw" = (
+/obj/machinery/camera{
+	c_tag = "Aft Port Solar Control";
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/wood,
+/area/library)
 "dUz" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/structure/disposalpipe/segment{
@@ -9479,9 +9798,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
 "dWp" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
 /area/engine/engineering)
 "dWH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -9560,7 +9886,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dXs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -9619,13 +9945,15 @@
 /turf/open/floor/plating,
 /area/medical/pharmacy)
 "dYz" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -9654,7 +9982,7 @@
 /area/maintenance/disposal/incinerator)
 "dZm" = (
 /turf/open/floor/plasteel/white,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "dZy" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -9667,9 +9995,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dZz" = (
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/engine/engineering)
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "dZK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9687,6 +10015,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"eas" = (
+/obj/structure/lattice,
+/obj/machinery/camera/autoname,
+/turf/open/space/basic,
+/area/engine/engine_room)
 "eaW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9767,11 +10100,12 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "ecN" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower";
+	pixel_y = -5
+	},
+/turf/open/floor/noslip,
 /area/engine/engineering)
 "ecW" = (
 /obj/effect/spawner/structure/window,
@@ -9893,6 +10227,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "efs" = (
@@ -10010,6 +10345,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"egS" = (
+/obj/structure/sign/painting/library_private{
+	pixel_y = -32
+	},
+/obj/structure/table/wood,
+/obj/item/cartridge/curator,
+/obj/item/toy/plush/ratplush,
+/turf/open/floor/plasteel/cult,
+/area/library)
 "ehc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -10341,6 +10685,19 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/janitor)
+"ern" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/radiation{
+	icon_state = "open";
+	id = "radiation shutters";
+	id_tag = null
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "erx" = (
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
@@ -10470,12 +10827,12 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "etK" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "etT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -10534,6 +10891,13 @@
 	},
 /turf/open/floor/circuit/off,
 /area/security/nuke_storage)
+"evT" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "ewl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -10554,6 +10918,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"ewF" = (
+/obj/item/stack/cable_coil,
+/turf/open/space/basic,
+/area/engine/engine_room)
 "exF" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -10588,6 +10956,7 @@
 	name = "Old Dorm"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
 "eyl" = (
@@ -10619,10 +10988,9 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "ezf" = (
-/obj/structure/lattice,
-/obj/item/airlock_painter,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/door/poddoor,
+/turf/open/floor/plating,
+/area/engine/storage)
 "ezU" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/closet/radiation,
@@ -10688,6 +11056,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"eAF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
+"eAG" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eAV" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -10784,9 +11165,6 @@
 "eCk" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
 /obj/machinery/light,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10820,6 +11198,21 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/green,
 /area/bridge)
+"eDk" = (
+/obj/item/stack/spacecash/c1{
+	pixel_x = 14;
+	pixel_y = 4
+	},
+/obj/item/stack/spacecash/c1{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/stack/spacecash/c1{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "eDO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -10878,6 +11271,9 @@
 	icon_state = "engi_e_crateopen"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "eEy" = (
@@ -11022,6 +11418,7 @@
 /obj/item/clothing/head/chameleon/broken,
 /obj/item/tank/jetpack/improvised,
 /obj/item/extendohand,
+/obj/item/gun/ballistic/automatic/toy/pistol/riot/unrestricted,
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/fore)
 "eHn" = (
@@ -11084,6 +11481,12 @@
 	dir = 6
 	},
 /area/quartermaster/office)
+"eJd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "eJf" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -11096,6 +11499,24 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/office/secretary)
+"eJx" = (
+/obj/item/stack/sheet/plasteel/twenty{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/stack/rods/fifty,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 5
+	},
+/area/engine/engineering)
 "eJL" = (
 /obj/structure/chair/comfy/lime,
 /turf/open/floor/carpet/royalblack,
@@ -11105,19 +11526,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/gateway)
-"eJR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room Main";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
 "eKa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 8
@@ -11350,6 +11758,13 @@
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/lab)
+"eOQ" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eOV" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/table,
@@ -11416,6 +11831,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"eQa" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "eQb" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/stripes/white/line,
@@ -11431,6 +11853,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "eQd" = (
@@ -11465,10 +11888,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "eQx" = (
-/obj/effect/turf_decal/loading_area{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eQT" = (
@@ -11622,6 +12051,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eTl" = (
@@ -11648,6 +12081,18 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"eTP" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/obj/structure/sign/painting/library_private{
+	pixel_y = 32
+	},
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/cult,
+/area/library)
 "eTR" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/cartridge/quartermaster{
@@ -11742,6 +12187,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eUS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eVe" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/flora/ausbushes/brflowers{
@@ -11825,6 +12276,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera/autoname,
+/obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "eWu" = (
@@ -11839,9 +12291,18 @@
 /turf/open/floor/carpet,
 /area/library)
 "eXf" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "eXw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -11896,6 +12357,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "eYw" = (
@@ -11908,12 +12370,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"eYI" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "eYK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "eYP" = (
@@ -12065,6 +12544,9 @@
 /obj/item/tank/internals/oxygen,
 /obj/item/geiger_counter,
 /obj/item/geiger_counter,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "faJ" = (
@@ -12072,21 +12554,22 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "faQ" = (
-/obj/item/stack/spacecash/c1{
-	pixel_y = -6
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"fbv" = (
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
 	},
-/obj/item/stack/spacecash/c1{
-	pixel_x = 16;
-	pixel_y = 10
+/obj/item/multitool,
+/obj/machinery/light_switch{
+	pixel_x = -4;
+	pixel_y = 24
 	},
-/obj/item/stack/spacecash/c1{
-	pixel_x = 10
-	},
-/obj/item/stack/spacecash/c1{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fbA" = (
 /obj/effect/turf_decal/stripes/line,
@@ -12121,7 +12604,7 @@
 	},
 /area/science/research)
 "fcG" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/l3closet,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fcY" = (
@@ -12263,6 +12746,12 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"fgz" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "fgK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -12427,16 +12916,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/mineral/titanium,
 /area/janitor)
+"fjR" = (
+/obj/machinery/field/generator/anchored,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "fjV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/medical/medbay/central)
 "fjZ" = (
 /obj/structure/flora/ausbushes/brflowers{
@@ -12766,6 +13255,13 @@
 /obj/machinery/computer/turbine_computer,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"fqN" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "fqP" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
@@ -12843,7 +13339,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -12852,14 +13347,12 @@
 	},
 /area/security/prison/rec)
 "fsw" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fsx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 9
@@ -12867,14 +13360,12 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "fsR" = (
-/obj/machinery/computer/nanite_chamber_control{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Nanite Lab";
 	dir = 8;
 	network = list("ss13","rd")
 	},
+/obj/machinery/nanite_chamber,
 /turf/open/floor/circuit/green,
 /area/science/nanite)
 "fsU" = (
@@ -12887,6 +13378,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
 	},
+/obj/item/analyzer,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ftj" = (
@@ -12908,15 +13400,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"ftL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "ftR" = (
 /obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
@@ -12966,6 +13449,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "fuN" = (
@@ -13036,6 +13520,9 @@
 	id = "executionburn";
 	pixel_x = 25
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "fwh" = (
@@ -13084,6 +13571,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "fwZ" = (
@@ -13097,6 +13590,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"fxc" = (
+/obj/effect/spawner/structure/window/hollow/middle{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/space/nearstation)
 "fxg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -13124,6 +13625,13 @@
 /obj/item/broken_bottle,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"fxG" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "fya" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/head/soft/green{
@@ -13201,6 +13709,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"fzU" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "fAg" = (
 /obj/item/papercutter,
 /obj/structure/table/wood,
@@ -13245,15 +13764,6 @@
 /obj/item/toy/figure/hos,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"fAC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fBp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -13271,6 +13781,10 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/engine/break_room)
+"fBM" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "fBN" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
@@ -13532,6 +14046,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/fore)
 "fHk" = (
@@ -13590,6 +14107,13 @@
 	},
 /turf/open/floor/grass,
 /area/security/prison/garden)
+"fIE" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "fIL" = (
 /obj/structure/window/reinforced/spawner,
 /mob/living/simple_animal/butterfly,
@@ -13603,6 +14127,13 @@
 /obj/item/toy/braintoy,
 /turf/closed/wall/r_wall,
 /area/medical/morgue)
+"fJi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "fJl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -13789,12 +14320,6 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"fMe" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "fMl" = (
 /obj/item/toy/beach_ball/holoball,
 /obj/effect/turf_decal/tile/green{
@@ -13834,7 +14359,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -13870,6 +14394,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "fNk" = (
@@ -13881,6 +14406,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -13932,15 +14463,6 @@
 	dir = 8
 	},
 /area/hallway/primary/central)
-"fNW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "fOi" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light{
@@ -14056,17 +14578,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plastic,
 /area/security/brig)
-"fPS" = (
-/obj/structure/barricade/wooden/crude,
-/obj/item/stack/sheet/metal,
-/turf/open/floor/plating/rust,
-/area/ruin/has_grav)
 "fQz" = (
-/obj/structure/cable,
-/obj/machinery/power/emitter/welded{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/pipe_dispenser,
+/obj/item/geiger_counter,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fQB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -14080,12 +14598,8 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/tank_holder/oxygen,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel,
 /area/engine/break_room)
 "fRd" = (
 /obj/effect/turf_decal/plaque{
@@ -14177,11 +14691,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fSo" = (
-/obj/structure/closet/crate/radiation,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
+/obj/structure/rack,
 /obj/effect/turf_decal/tile/yellow,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "fSu" = (
@@ -14221,7 +14733,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/medical/chemistry)
 "fTh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -14293,6 +14805,11 @@
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
+"fVk" = (
+/obj/machinery/door/poddoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engine/storage)
 "fVs" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -14344,6 +14861,9 @@
 /obj/structure/rack,
 /obj/item/clothing/under/rank/security/officer/grey,
 /obj/item/clothing/under/rank/security/warden/grey,
+/obj/item/clothing/under/rank/security/head_of_security/grey{
+	pixel_y = 4
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/brig)
 "fWm" = (
@@ -14438,6 +14958,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "fWJ" = (
@@ -14450,14 +14973,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
-"fWM" = (
-/obj/effect/turf_decal/caution,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "fXe" = (
-/mob/living/simple_animal/hostile/cockroach,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "fXi" = (
 /obj/machinery/light/small{
@@ -14466,9 +14984,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fXj" = (
-/obj/item/melee/moonlight_greatsword,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/port)
 "fXr" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/mechanical,
@@ -14627,12 +15152,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "gbf" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "gbi" = (
 /obj/structure/table/glass,
 /obj/item/cartridge/medical{
@@ -14652,6 +15180,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"gbM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "misclab";
+	name = "test chamber blast door"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "gci" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
@@ -14765,7 +15302,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "gdm" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -14956,10 +15493,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"ghR" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "gif" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -14988,6 +15521,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"gjd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "gjj" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -15025,6 +15564,7 @@
 /area/crew_quarters/kitchen)
 "gjA" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison/garden)
 "gke" = (
@@ -15068,6 +15608,10 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"glp" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/solars/port/aft)
 "gls" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Prison Forestry"
@@ -15091,6 +15635,16 @@
 /obj/structure/cable,
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
+"glz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "glI" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -15114,7 +15668,6 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -15184,6 +15737,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"gnl" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gnm" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Cell 1"
@@ -15275,12 +15834,8 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
 "gou" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/closed/wall,
+/area/security/checkpoint/customs)
 "gow" = (
 /obj/structure/table,
 /obj/item/tank/jetpack/oxygen/security,
@@ -15399,11 +15954,15 @@
 /turf/open/floor/circuit,
 /area/tcommsat/server)
 "gsm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
 	},
-/turf/open/floor/plasteel/cult,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "gsG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -15448,6 +16007,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/library)
 "gtn" = (
@@ -15516,9 +16076,6 @@
 "guc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/chair/office{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/library)
 "gux" = (
@@ -15553,11 +16110,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"guP" = (
-/obj/structure/cable,
-/obj/item/taperecorder,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "gvh" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -15589,6 +16141,21 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/central)
+"gvF" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "Tesla Storage";
+	name = "Tesla Storage";
+	pixel_x = 25;
+	req_access_txt = "56"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "gvM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -15654,12 +16221,24 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"gwZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gxM" = (
 /obj/structure/flora/rock/pile/largejungle{
 	pixel_x = 0;
 	pixel_y = -31
 	},
 /obj/structure/flora/grass/jungle,
+/obj/structure/flora/junglebush/large{
+	pixel_x = -4;
+	pixel_y = -24
+	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "gxS" = (
@@ -15737,7 +16316,7 @@
 	name = "RD Shutter Control";
 	pixel_x = 8;
 	pixel_y = 26;
-	req_access_txt = "40"
+	req_access_txt = "30"
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/heads/hor)
@@ -15787,14 +16366,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"gzZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	frequency = 1441;
-	id = "inc_in"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "gAd" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/computer/med_data/laptop{
@@ -15896,6 +16467,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/rec)
 "gCa" = (
@@ -16025,6 +16597,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison/garden)
 "gDS" = (
@@ -16051,6 +16624,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gEz" = (
@@ -16094,16 +16668,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"gFm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
 "gFN" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
@@ -16117,6 +16681,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"gFS" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "gGc" = (
 /obj/machinery/suit_storage_unit/cmo,
 /turf/open/floor/mineral/titanium/blue,
@@ -16154,12 +16722,23 @@
 	c_tag = "Uniform Room";
 	dir = 8
 	},
+/obj/item/clothing/suit/armor/vest/russian_coat{
+	armor = list("melee" = 15, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 45);
+	desc = "Used in extremly cold fronts. This particular coat is degraded and full of holes.";
+	name = "Old russian coat"
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/brig)
 "gGw" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/grounding_rod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gGD" = (
@@ -16199,8 +16778,14 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/under/pants/red,
+/obj/item/clothing/under/pants/track,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
+"gHd" = (
+/obj/item/crowbar/large,
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "gHm" = (
 /obj/item/flashlight,
 /turf/open/floor/plating,
@@ -16226,10 +16811,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"gHB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+"gHL" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "gHY" = (
 /obj/structure/table,
 /obj/item/blackmarket_uplink,
@@ -16250,6 +16837,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "gIn" = (
@@ -16275,15 +16863,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
 	name = "Medbay";
 	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -16299,6 +16887,12 @@
 /obj/item/instrument/violin,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"gIY" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gJd" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/stripes/line{
@@ -16354,6 +16948,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gJK" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gJQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -16371,11 +16970,19 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "gKs" = (
-/obj/structure/grille/broken,
-/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gKw" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "gKD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -16402,6 +17009,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"gLb" = (
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "gLn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16517,9 +17130,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gNy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -16590,6 +17200,7 @@
 	},
 /obj/item/clothing/mask/breath,
 /obj/effect/turf_decal/bot,
+/obj/item/crowbar/red,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "gPe" = (
@@ -16624,6 +17235,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"gPq" = (
+/obj/effect/turf_decal/caution,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "gPD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
@@ -16972,6 +17587,9 @@
 	req_access_txt = "31"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
 "gWK" = (
@@ -16988,6 +17606,16 @@
 	dir = 4
 	},
 /area/hallway/primary/central)
+"gWO" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Gas"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gWR" = (
 /obj/machinery/light{
 	dir = 4
@@ -17086,10 +17714,15 @@
 	},
 /obj/machinery/door/window{
 	dir = 1;
-	name = "Poly's Pen"
+	name = "Poly's Pen";
+	req_one_access_txt = "56"
 	},
 /obj/structure/bed/dogbed{
 	name = "bird bed"
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	pixel_y = -29
 	},
 /turf/open/floor/plating/sandy_dirt,
 /area/crew_quarters/heads/chief)
@@ -17105,6 +17738,10 @@
 /obj/structure/closet/crate/internals,
 /obj/item/stack/marker_beacon/ten,
 /obj/item/pickaxe/mini,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/shovel,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "gYs" = (
@@ -17296,6 +17933,10 @@
 /obj/item/cautery,
 /turf/open/floor/plastic,
 /area/medical/surgery)
+"hbk" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "hbw" = (
 /obj/item/paper_bin,
 /obj/structure/table,
@@ -17406,6 +18047,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
+"hdl" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "hdw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/iv_drip,
@@ -17417,7 +18064,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "hdJ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -17459,13 +18106,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "heB" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/structure/lattice,
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/bar,
-/obj/item/food/cnds,
-/turf/open/floor/plasteel/cafeteria,
-/area/maintenance/fore)
+/turf/open/space/basic,
+/area/space/nearstation)
 "heH" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -17556,6 +18202,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "hfj" = (
@@ -17729,6 +18376,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "hjb" = (
@@ -17755,6 +18403,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"hji" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "hjk" = (
 /obj/structure/table/glass,
 /obj/item/aicard,
@@ -17837,10 +18495,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/structure/mirror{
-	icon_state = "mirror_broke";
-	pixel_y = 28
 	},
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18470,6 +19124,11 @@
 	dir = 6
 	},
 /area/medical/storage)
+"hwM" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hwP" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -18490,7 +19149,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "hwV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -18527,6 +19186,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"hxO" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hxR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -18577,8 +19241,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "hyp" = (
-/obj/structure/tank_holder/oxygen,
-/turf/open/floor/plating,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/space/nearstation)
 "hyv" = (
 /obj/effect/turf_decal/tile/bar,
@@ -18766,6 +19432,10 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/heads/hor)
+"hBX" = (
+/obj/structure/fireplace,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "hCk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18861,11 +19531,13 @@
 /turf/open/floor/wood,
 /area/library)
 "hDN" = (
-/obj/machinery/smartfridge/drinks{
-	icon_state = "boozeomat"
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
 	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
+/obj/effect/turf_decal/tile/bar,
+/obj/item/food/cnds,
+/turf/open/floor/plasteel/cafeteria,
+/area/maintenance/fore)
 "hDT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -18979,9 +19651,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hFm" = (
-/obj/item/pickaxe/mini,
-/obj/structure/window/spawner/west,
-/turf/open/floor/plating/asteroid,
+/obj/structure/table/wood,
+/obj/item/stack/cable_coil,
+/obj/machinery/light,
+/obj/item/reagent_containers/food/drinks/soda_cans/grey_bull,
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "hFo" = (
 /obj/structure/cable,
@@ -19033,11 +19707,27 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"hGe" = (
+/obj/structure/table,
+/obj/item/trash/candle{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "hGj" = (
 /obj/machinery/processor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/fore)
+"hGn" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "hGw" = (
 /obj/item/extinguisher,
 /obj/structure/rack,
@@ -19173,6 +19863,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hJR" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/engine/engineering)
 "hKl" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
@@ -19215,6 +19916,12 @@
 	name = "Maintenance Hatch";
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hLw" = (
@@ -19222,6 +19929,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "hMf" = (
@@ -19286,10 +19994,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"hNh" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hNm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -19344,10 +20048,15 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "hOO" = (
-/obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"hOP" = (
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "hPh" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -19357,8 +20066,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/chapel/office)
 "hPr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -19367,7 +20082,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "hPK" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hQd" = (
@@ -19422,8 +20137,8 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hQS" = (
-/turf/open/floor/plating/asteroid,
-/area/ruin/has_grav)
+/turf/open/space/basic,
+/area/space/nearstation)
 "hQY" = (
 /turf/closed/indestructible{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
@@ -19445,6 +20160,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"hRm" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/clothing/glasses/sunglasses,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "hRu" = (
 /obj/structure/mopbucket,
 /obj/structure/window{
@@ -19548,9 +20275,11 @@
 /turf/open/space/basic,
 /area/space)
 "hST" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating/rust,
-/area/maintenance/port/aft)
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot_white,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "hTf" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -19568,6 +20297,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hTh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "hTi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -19619,9 +20356,9 @@
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "hTY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -19669,13 +20406,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"hUL" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "hUM" = (
 /obj/machinery/vending/wallmed,
 /turf/closed/wall,
@@ -19708,6 +20438,7 @@
 "hVm" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
+/obj/item/crowbar/red,
 /turf/open/floor/plating,
 /area/storage/emergency/port)
 "hVv" = (
@@ -19791,10 +20522,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "hXj" = (
-/obj/structure/lattice,
-/mob/living/simple_animal/hostile/lizard/space,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/power/tesla_coil,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "hXC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -19864,12 +20595,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hZg" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hZl" = (
 /obj/structure/closet/bombcloset,
 /obj/effect/turf_decal/bot_white,
@@ -19963,6 +20691,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iae" = (
+/obj/structure/sign/painting/library_private{
+	pixel_y = -32
+	},
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/plasteel/cult,
+/area/library)
 "iam" = (
 /obj/structure/sign/painting/library{
 	pixel_y = 32
@@ -19978,10 +20713,13 @@
 /turf/open/floor/wood,
 /area/library)
 "iap" = (
-/obj/machinery/computer/station_alert,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ias" = (
@@ -20060,6 +20798,13 @@
 	dir = 4
 	},
 /area/bridge)
+"icZ" = (
+/obj/machinery/computer{
+	desc = "A very suspicious console with navigational markings on its display. It appears to be broken.";
+	name = "Meteor control shuttle"
+	},
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "ida" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -20090,6 +20835,23 @@
 "idF" = (
 /turf/closed/wall/r_wall,
 /area/storage/primary)
+"ieL" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
+"ieX" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "ifb" = (
 /mob/living/simple_animal/hostile/retaliate/frog,
 /turf/open/floor/grass,
@@ -20200,19 +20962,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "igt" = (
-/obj/structure/particle_accelerator/power_box{
+/obj/structure/reflector/box/anchored{
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"igK" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "igR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
@@ -20354,12 +21108,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"ijE" = (
-/obj/structure/window/spawner/west,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/space/nearstation)
 "ijF" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
@@ -20447,6 +21195,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ikD" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ikJ" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -20492,7 +21246,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/item/kirbyplants/random,
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -20509,6 +21262,12 @@
 /obj/item/analyzer,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"imu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "imy" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
@@ -20600,6 +21359,12 @@
 /obj/item/stack/tile/carpet/donk/thirty,
 /turf/open/floor/carpet/donk,
 /area/maintenance/starboard/aft)
+"iob" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/maintenance/port/aft)
 "iok" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -20616,6 +21381,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ioo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ioq" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -20692,18 +21467,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"iqT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/engine/engine_room)
 "irn" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "irr" = (
@@ -20814,6 +21589,13 @@
 /obj/item/shard,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered)
+"itw" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "itN" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot/right,
@@ -20838,8 +21620,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -20875,6 +21657,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"iuu" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "iuw" = (
 /turf/open/floor/plasteel/dark,
 /area/security/prison/visit)
@@ -20919,11 +21708,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ivl" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ivt" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
@@ -20962,15 +21746,19 @@
 /turf/open/floor/plating,
 /area/security/prison/visit)
 "iwm" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 32
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
+"iws" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green,
 /area/engine/gravity_generator)
 "ixz" = (
 /obj/structure/window/reinforced{
@@ -21030,6 +21818,15 @@
 /obj/machinery/light,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"iyn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"iyw" = (
+/obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "iyL" = (
 /obj/machinery/button/door{
 	id = "xenobio2";
@@ -21050,10 +21847,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "iyT" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/item/storage/firstaid/toxin,
-/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "izg" = (
@@ -21162,6 +21958,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "iBl" = (
@@ -21203,22 +22005,19 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "iCC" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
-/turf/open/floor/carpet,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "iCR" = (
 /obj/machinery/vending/cola/black,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
-"iDa" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
 "iDl" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/structure/reagent_dispensers/peppertank{
@@ -21437,6 +22236,14 @@
 	dir = 4
 	},
 /area/science/research)
+"iHe" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iHr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -21445,10 +22252,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
-"iHN" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iHT" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
@@ -21533,19 +22336,9 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "iJs" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Shared Engineering Storage";
-	req_one_access_txt = "32;19"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/engine/atmos)
 "iJx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21600,6 +22393,7 @@
 	},
 /obj/structure/window,
 /obj/item/storage/toolbox/electrical,
+/obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "iKh" = (
@@ -21649,12 +22443,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "iKL" = (
-/obj/structure/window/spawner,
-/obj/effect/turf_decal/weather,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
 "iKT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -21720,6 +22511,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
+"iLH" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix Bypass"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "iLM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -21888,10 +22690,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "iQM" = (
-/obj/machinery/camera/autoname{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/turf/open/space/basic,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "iQQ" = (
 /obj/machinery/light{
@@ -21976,6 +22779,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"iRT" = (
+/obj/item/geiger_counter,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "iRV" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/stripes/line,
@@ -21990,17 +22797,26 @@
 "iRY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "iRZ" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/portable_atmospherics/pump,
 /obj/machinery/camera{
 	c_tag = "Atmospherics South East";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -22065,12 +22881,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "iUb" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -22112,8 +22922,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "iVe" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/emergency,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "iVp" = (
@@ -22138,6 +22947,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/holofloor/dark,
 /area/science/mixing)
+"iXK" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iXP" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -22225,9 +23040,10 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "iYN" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/aft)
+/turf/open/space/basic,
+/area/maintenance/solars/port/aft)
 "iYY" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Office";
@@ -22319,17 +23135,20 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "jak" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/obj/machinery/camera/autoname{
+/obj/effect/turf_decal/arrows{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "jao" = (
 /obj/machinery/camera/autoname,
 /turf/open/space/basic,
 /area/space)
+"jas" = (
+/obj/structure/girder/displaced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jaz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /mob/living/simple_animal/hostile/cockroach,
@@ -22360,6 +23179,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"jbo" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "jbu" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -22429,10 +23255,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"jcU" = (
-/obj/item/banner/medical,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "jdc" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/delivery,
@@ -22445,6 +23267,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "jdn" = (
@@ -22460,13 +23283,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jdt" = (
-/obj/structure/table/wood,
-/obj/item/storage/bag/books,
-/obj/item/toy/cards/deck/syndicate,
-/obj/item/key/displaycase,
-/turf/open/floor/plasteel/cult,
-/area/library)
+"jdq" = (
+/obj/structure/tank_holder/oxygen,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "jdu" = (
 /obj/structure/chair/sofa/corner{
 	dir = 8
@@ -22548,24 +23368,11 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/item/clothing/glasses/science{
 	pixel_y = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"jgf" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
-/obj/structure/sign/painting/library_private{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/cult,
-/area/library)
 "jgh" = (
 /obj/effect/turf_decal/sand,
 /obj/structure/table/wood,
@@ -22613,8 +23420,8 @@
 	c_tag = "Brig Prison Hallway";
 	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -22742,12 +23549,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
+"jjg" = (
+/obj/structure/lattice,
+/obj/structure/window/spawner,
+/turf/open/space/basic,
+/area/maintenance/port/aft)
 "jjK" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/structure/musician/piano{
+	icon_state = "piano"
 	},
-/area/space/nearstation)
+/turf/open/floor/carpet,
+/area/maintenance/port/aft)
 "jjL" = (
 /obj/machinery/camera{
 	c_tag = "Testing Lab";
@@ -22811,6 +23623,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jku" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
+"jkC" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jkY" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/clothing/shoes/sneakers/white,
@@ -22877,6 +23705,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"jlx" = (
+/obj/structure/table/wood,
+/obj/item/storage/bag/books,
+/obj/item/toy/cards/deck/syndicate,
+/obj/item/key/displaycase,
+/obj/structure/sign/painting/library_private{
+	pixel_y = -32
+	},
+/obj/structure/sign/painting/library_private{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/cult,
+/area/library)
 "jlC" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -22909,6 +23750,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"jmg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jmh" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
@@ -23196,6 +24046,12 @@
 /obj/item/clothing/under/rank/rnd/geneticist,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"jrc" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jrg" = (
 /obj/machinery/computer/cargo/request,
 /obj/effect/turf_decal/tile/brown{
@@ -23265,9 +24121,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"jsL" = (
-/turf/open/floor/circuit/off,
-/area/engine/gravity_generator)
 "jsW" = (
 /obj/structure/chair{
 	dir = 1
@@ -23403,6 +24256,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"jvr" = (
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "jvz" = (
 /obj/effect/turf_decal/bot/right,
 /obj/effect/landmark/start/cargo_technician,
@@ -23462,7 +24319,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/white/medical,
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -13;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "jwe" = (
@@ -23510,10 +24371,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "jxh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "incinerator mix pump"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jxr" = (
@@ -23650,7 +24510,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "jAw" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/neutral{
@@ -23794,9 +24654,6 @@
 	red_alert_access = 1;
 	req_access_txt = "5"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/dark,
@@ -23881,6 +24738,19 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"jDs" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "jDv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23923,6 +24793,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jEC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jEE" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -24038,6 +24916,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jFM" = (
+/obj/effect/landmark/start/voidtech,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jFN" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -24111,6 +24993,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"jHj" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/maintenance/solars/port/aft)
 "jHl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -24182,10 +25068,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "jJa" = (
-/obj/structure/cable,
-/obj/machinery/power/emitter/welded,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "jJm" = (
 /turf/closed/wall,
 /area/storage/tech)
@@ -24216,6 +25105,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jJV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jKg" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -24272,6 +25167,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/bridge)
+"jKr" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jKu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -24293,6 +25197,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"jKB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room Main";
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "jKC" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/closet/crate/coffin,
@@ -24345,8 +25262,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jMA" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jMC" = (
@@ -24366,11 +25286,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jMP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "jNi" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -24526,8 +25441,11 @@
 /area/hallway/primary/central)
 "jPN" = (
 /obj/effect/turf_decal/sand,
-/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal{
+	pixel_x = -10
+	},
 /obj/item/clothing/under/costume/scarecrow{
+	pixel_x = 5;
 	pixel_y = 12
 	},
 /turf/open/floor/plating,
@@ -24631,7 +25549,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/chapel/office)
 "jRf" = (
 /obj/structure/bed/maint,
 /obj/item/food/breadslice/moldy,
@@ -24714,6 +25632,16 @@
 "jTi" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"jTq" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "jTy" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment,
@@ -24754,8 +25682,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "jTY" = (
-/obj/machinery/light,
-/turf/open/floor/engine,
+/obj/machinery/power/emitter/welded{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "jUE" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
@@ -24779,6 +25711,26 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"jVI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"jWe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "jWk" = (
 /obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plastic,
@@ -24868,11 +25820,6 @@
 	pixel_y = -32
 	},
 /obj/structure/cable,
-/obj/machinery/camera/motion{
-	c_tag = "Telecomms Server Room";
-	dir = 1;
-	network = list("tcomms")
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -24886,17 +25833,13 @@
 /turf/closed/wall,
 /area/engine/break_room)
 "jYB" = (
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/noslip,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "jYK" = (
 /obj/structure/table/glass,
@@ -25046,6 +25989,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"kby" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 32
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "kbM" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -25098,17 +26052,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kdm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
-"kdr" = (
-/obj/item/stack/sticky_tape,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
 "kds" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -25223,6 +26166,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/brig)
+"kfi" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kfp" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/effect/turf_decal/tile/purple{
@@ -25473,6 +26423,12 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "kkz" = (
@@ -25503,6 +26459,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kkS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kkU" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -25510,10 +26485,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
 	},
 /obj/effect/landmark/secequipment,
 /turf/open/floor/plasteel/showroomfloor,
@@ -25620,14 +26591,12 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "kmT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "knp" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -25669,6 +26638,15 @@
 	},
 /turf/open/floor/circuit/off,
 /area/science/server)
+"kou" = (
+/obj/structure/table,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "koE" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/item/reagent_containers/glass/bucket/wooden,
@@ -25727,11 +26705,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kpX" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "kqv" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -25845,12 +26818,21 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "krJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/field/generator,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
 /area/engine/engineering)
 "krR" = (
 /obj/structure/table/reinforced,
@@ -25879,12 +26861,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ksK" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "ksS" = (
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/engine,
@@ -25954,6 +26934,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
 "ktE" = (
@@ -26198,13 +27179,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison/garden)
 "kxl" = (
-/obj/item/toy/cards/deck,
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes/cigpack_candy,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kxq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26219,6 +27201,11 @@
 	},
 /turf/open/floor/circuit,
 /area/tcommsat/computer)
+"kxs" = (
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/turf/open/floor/plasteel/solarpanel,
+/area/maintenance/solars/port/aft)
 "kxB" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -26302,13 +27289,13 @@
 	},
 /area/holodeck/rec_center)
 "kAj" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating/asteroid,
-/area/maintenance/port/aft)
-"kAm" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"kAm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
@@ -26409,6 +27396,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"kCD" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/flashlight,
+/obj/item/crowbar/large,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "kCH" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
 /turf/open/floor/plating,
@@ -26482,7 +27476,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/dorms)
 "kEg" = (
 /obj/structure/fluff/hedge,
 /obj/structure/disposalpipe/segment{
@@ -26535,12 +27529,23 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kGk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "kGp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"kGH" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "kGV" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -26565,24 +27570,46 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "kHs" = (
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
 /obj/machinery/disposal/bin,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/machinery/button/door{
-	id = "ceprivacy";
-	name = "Privacy Shutters Control";
+	id = "Tesla Storage";
+	name = "Tesla Storage";
 	pixel_x = -25;
-	pixel_y = -10
+	req_access_txt = "56"
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/button/door{
+	id = "ceprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = -25;
+	pixel_y = -10;
+	req_access_txt = "56"
+	},
+/obj/machinery/button/door{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_x = -25;
+	pixel_y = 10;
+	req_access_txt = "56"
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
+"kHz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "kHE" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/light/small{
@@ -26703,16 +27730,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "kJN" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/machinery/navbeacon/wayfinding/engineering,
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "kJP" = (
 /obj/structure/cable,
@@ -26767,6 +27789,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"kKM" = (
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/pharmacy)
 "kLw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -26909,6 +27950,11 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
+"kNh" = (
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kNi" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -27040,6 +28086,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"kOW" = (
+/obj/structure/safe,
+/obj/item/clothing/under/syndicate/tacticool/skirt,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
+/obj/item/crowbar/syndie{
+	desc = "There used to be huge fields of these used to mark out shuttle landing zones, now only 1 remains.";
+	name = "The last crowbar"
+	},
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "kPh" = (
 /turf/closed/wall/rust,
 /area/maintenance/port/aft)
@@ -27064,14 +28122,15 @@
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/service)
 "kPu" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
 	req_one_access_txt = "10;24"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "kPw" = (
@@ -27084,6 +28143,10 @@
 "kPz" = (
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"kPB" = (
+/obj/item/hatchet/wooden,
+/turf/open/floor/plating/asteroid,
+/area/ruin/has_grav)
 "kPH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27106,6 +28169,11 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"kQi" = (
+/obj/structure/fluff/hedge,
+/obj/item/toy/plush/goatplushie,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "kQs" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -27139,7 +28207,7 @@
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "kQM" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -27153,15 +28221,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "kRo" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "kRJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -27178,10 +28245,11 @@
 /turf/open/floor/wood,
 /area/hydroponics/garden)
 "kSk" = (
-/obj/item/clothing/under/rank/engineering/signal_tech,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "kSm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27288,7 +28356,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "kTG" = (
 /obj/structure/chair/stool,
 /turf/open/floor/glass/reinforced,
@@ -27367,13 +28435,11 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "kVh" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "kVo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -27405,10 +28471,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
-"kVZ" = (
-/obj/item/food/grown/citrus/orange_3d,
-/turf/open/floor/plasteel/sepia,
-/area/ruin/has_grav)
+"kVB" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "kWf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -27465,6 +28533,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kXm" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kXn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -27605,9 +28680,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kZB" = (
-/obj/machinery/field/generator,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "kZI" = (
 /obj/structure/fluff/hedge,
@@ -27648,9 +28724,11 @@
 	},
 /area/science/research)
 "laV" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -27708,8 +28786,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -27830,6 +28908,7 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
+/obj/effect/landmark/start/librarian,
 /turf/open/floor/carpet,
 /area/library)
 "leb" = (
@@ -27946,6 +29025,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lgt" = (
@@ -28142,10 +29222,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison/garden)
 "ljZ" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/structure/cable,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "lkc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -28264,17 +29346,9 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/service)
 "lmK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/radiation{
-	icon_state = "open";
-	id = "radiation shutters";
-	id_tag = null
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "SM shutters"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -28307,9 +29381,14 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"lmW" = (
-/obj/structure/closet/secure_closet/void,
-/turf/open/floor/plasteel,
+"lnd" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Gas to Mix"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "lnh" = (
 /obj/effect/turf_decal/tile/blue{
@@ -28323,6 +29402,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"lnv" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "lnB" = (
 /obj/effect/turf_decal/trimline/red/warning,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -28511,10 +29594,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sink/kitchen{
-	name = "utility sink";
-	pixel_y = 28
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "lqW" = (
@@ -28613,11 +29692,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lsT" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ltj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -28728,14 +29802,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "lvd" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
 /area/hallway/primary/central)
 "lvf" = (
 /obj/effect/turf_decal/trimline/red/line,
@@ -28782,6 +29861,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningoffice)
+"lvA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lwn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -28828,6 +29914,10 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
+"lxq" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/solarpanel,
+/area/maintenance/solars/port/aft)
 "lxx" = (
 /obj/structure/chair{
 	dir = 1
@@ -28881,6 +29971,14 @@
 /obj/machinery/atmospherics/pipe/simple,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"lyh" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Gravity Generator External Hull West";
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "lys" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -29026,13 +30124,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "lBI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
 	},
-/obj/item/wrench,
-/obj/item/screwdriver,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lBM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -29052,6 +30149,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"lCa" = (
+/obj/structure/destructible/cult/tome,
+/obj/item/book/codex_gigas,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult,
+/area/library)
 "lCl" = (
 /obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/dark,
@@ -29110,6 +30215,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"lCY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "lDd" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -29149,7 +30264,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lDl" = (
-/obj/machinery/door/airlock/wood/glass,
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -29174,11 +30292,10 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lEk" = (
-/mob/living/simple_animal/pet/cat/space,
-/turf/open/floor/plasteel/airless{
-	icon_state = "damaged3"
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 8
 	},
-/area/space/nearstation)
+/area/maintenance/port/aft)
 "lEu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29328,6 +30445,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/janitor)
+"lGc" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "lGi" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -29389,6 +30511,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"lHN" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "lHY" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -29443,9 +30573,11 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "lIU" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lJq" = (
@@ -29492,6 +30624,12 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -29570,12 +30708,24 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
+"lKP" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = null;
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "lLl" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/bio,
 /obj/item/storage/bag/bio,
 /obj/item/storage/bag/bio,
 /obj/machinery/airalarm/directional/north,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
 "lLm" = (
@@ -29586,6 +30736,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "lLr" = (
@@ -29599,7 +30750,14 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/medical/virology)
+"lLu" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "lLv" = (
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -29708,6 +30866,13 @@
 	dir = 1
 	},
 /area/hallway/secondary/service)
+"lNc" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "lNh" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -29717,7 +30882,7 @@
 	name = "Teleporter Shutters";
 	pixel_x = -26;
 	pixel_y = 6;
-	req_access_txt = "31"
+	req_access_txt = "17"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29732,7 +30897,7 @@
 /obj/structure/fluff/hedge{
 	layer = 2.8
 	},
-/turf/open/floor/grass,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden)
 "lNZ" = (
 /obj/effect/turf_decal/trimline/red/line,
@@ -29843,12 +31008,15 @@
 /turf/open/floor/plasteel/checker,
 /area/crew_quarters/theatre)
 "lPQ" = (
-/obj/item/toy/figure/atmos,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/structure/table,
+/obj/item/clothing/head/beret/atmos,
+/obj/item/clothing/head/beret/atmos{
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "lPX" = (
@@ -29943,6 +31111,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "lRA" = (
@@ -29989,13 +31158,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
 /area/bridge)
-"lRP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "lRU" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -30030,7 +31192,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "lSP" = (
@@ -30067,6 +31232,12 @@
 "lTt" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -30108,12 +31279,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/library)
+"lTV" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
+/obj/item/storage/belt/utility,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "lUb" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"lUc" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lUe" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -30210,6 +31394,10 @@
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating,
 /area/crew_quarters/office/secretary)
+"lVt" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "lVU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light{
@@ -30325,11 +31513,12 @@
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
 "lXW" = (
-/obj/structure/window/spawner,
-/obj/effect/turf_decal/weather,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lYu" = (
 /obj/machinery/door/airlock/security{
 	name = "Court Cell";
@@ -30351,6 +31540,11 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/item/clothing/under/syndicate/camo{
+	has_sensor = 1;
+	random_sensor = 0;
+	sensor_mode = 3
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -30406,9 +31600,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "lYN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/void,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "lYO" = (
@@ -30419,18 +31611,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/office/secretary)
 "lZd" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "lZK" = (
 /obj/effect/turf_decal/stripes/end{
@@ -30549,10 +31733,8 @@
 /area/hallway/secondary/entry)
 "mbR" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/machinery/restaurant_portal/bar{
-	pixel_y = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mcr" = (
@@ -30635,6 +31817,15 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "mdw" = (
@@ -30687,10 +31878,12 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "meK" = (
-/obj/machinery/power/grounding_rod,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
 /area/engine/engineering)
 "meN" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -30737,6 +31930,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/sign/departments/engineering{
 	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -30791,15 +31987,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "mhK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/void,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -30933,6 +32121,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mjO" = (
+/obj/effect/turf_decal/weather,
 /turf/open/floor/plating/rust,
 /area/ruin/has_grav)
 "mka" = (
@@ -31146,11 +32335,18 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "mna" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/closet/crate/trashcart/filled,
-/obj/item/toy/plush/awakenedplushie,
-/turf/open/floor/plasteel,
-/area/security/prison/rec)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"mnd" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "mob" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -31207,9 +32403,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "moO" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/solar/port/aft)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "mpq" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Test Chamber";
@@ -31280,12 +32476,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/analyzer,
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "mqv" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 4
+	},
 /area/maintenance/port/aft)
 "mqF" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31522,8 +32719,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/chair/stool,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/wardrobe/white/medical,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "mwo" = (
@@ -31622,14 +32819,6 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 9;
-	pixel_x = -16
-	},
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1;
-	pixel_x = 16
-	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "mxf" = (
@@ -31674,20 +32863,24 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "myv" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/medical{
-	pixel_y = 2
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/pinpointer/crew,
-/obj/item/defibrillator,
-/obj/item/sensor_device,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/table/glass,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
 "myz" = (
@@ -31836,6 +33029,12 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"mBe" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "mBf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -31857,16 +33056,22 @@
 /area/crew_quarters/office/secretary)
 "mBm" = (
 /obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "mBn" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
+"mBJ" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/maintenance/solars/port/aft)
 "mBO" = (
 /obj/item/pickaxe/mini,
 /obj/effect/decal/cleanable/generic,
@@ -31915,11 +33120,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mDC" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
+/obj/item/melee/moonlight_greatsword,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "mDG" = (
@@ -31938,6 +33148,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"mDL" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "mDV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -31965,6 +33183,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"mDY" = (
+/obj/machinery/power/grounding_rod,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "mEj" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -32045,6 +33268,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"mGq" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "mGE" = (
 /obj/machinery/light{
 	dir = 1
@@ -32113,8 +33346,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "mHC" = (
-/obj/machinery/power/grounding_rod,
+/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mHI" = (
@@ -32127,6 +33363,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"mHT" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "mIe" = (
 /obj/machinery/light{
 	dir = 1
@@ -32503,18 +33743,17 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/science/research)
 "mPO" = (
 /obj/machinery/vending/tool,
 /obj/structure/window,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "mPP" = (
-/obj/structure/particle_accelerator/particle_emitter/right{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mPQ" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -32551,6 +33790,9 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
 	},
@@ -32585,6 +33827,19 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/security/prison)
+"mRP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mRS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -32641,17 +33896,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "mSL" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engineering";
-	req_one_access_txt = "10;24;19"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "mTb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -32676,6 +33924,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/brig)
 "mTy" = (
@@ -32702,6 +33951,15 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
+"mUi" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "mUm" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 8;
@@ -32741,10 +33999,11 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "mUI" = (
-/obj/machinery/power/tesla_coil,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
 /obj/effect/turf_decal/bot,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mVj" = (
 /obj/structure/sign/warning/securearea{
@@ -32790,8 +34049,9 @@
 /turf/closed/wall,
 /area/quartermaster/office)
 "mVw" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mVy" = (
@@ -32815,6 +34075,12 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mVE" = (
@@ -33252,7 +34518,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "nax" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -33260,6 +34526,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"naK" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "naL" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/delivery,
@@ -33285,7 +34558,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "nbX" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -33389,11 +34662,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/bridge)
-"neh" = (
-/obj/structure/fluff/hedge,
-/obj/item/toy/plush/goatplushie,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "nel" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -33554,6 +34822,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "nga" = (
@@ -33593,6 +34862,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"ngz" = (
+/obj/structure/table/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/flashlight/lamp/green{
+	layer = 3.1;
+	pixel_y = 8
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_robust{
+	pixel_y = -10
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/bar)
 "ngD" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -33696,11 +34979,12 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "nia" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/open/floor/plasteel/sepia,
-/area/ruin/has_grav)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "niy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -33742,8 +35026,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/storage)
 "niX" = (
-/obj/structure/fireplace,
-/turf/open/floor/wood,
+/obj/structure/table/reinforced,
+/obj/item/stack/package_wrap,
+/obj/item/assembly/flash/handheld,
+/obj/item/hand_labeler,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "njd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -33789,6 +35077,11 @@
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/memeorgans,
+/obj/structure/mirror{
+	icon_state = "mirror_broke";
+	pixel_x = -28;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "njw" = (
@@ -33796,6 +35089,12 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"njD" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "njQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -33807,6 +35106,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"njS" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "njT" = (
 /obj/structure/table/glass,
 /obj/machinery/cell_charger,
@@ -33845,10 +35157,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
-"nkq" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engine/engineering)
 "nkv" = (
 /obj/machinery/chem_heater,
 /obj/effect/turf_decal/tile/yellow{
@@ -33970,9 +35278,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "nmp" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nmr" = (
@@ -34006,22 +35313,19 @@
 /turf/open/floor/plating/rust,
 /area/chapel/office)
 "nmI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "nmR" = (
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "nnT" = (
-/turf/open/floor/plating/rust,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nod" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -34091,7 +35395,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
 /area/hallway/primary/central)
 "nqi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -34118,6 +35427,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nqG" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Electrical Maintenance";
+	req_access_txt = "11"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nrp" = (
 /obj/structure/table,
 /obj/item/clothing/head/beret/mining,
@@ -34244,6 +35562,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"nsW" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "ntd" = (
 /obj/structure/disposalpipe/sorting/wrap{
 	dir = 1
@@ -34655,11 +35977,6 @@
 /obj/structure/chair,
 /turf/open/floor/carpet,
 /area/security/main)
-"nzY" = (
-/turf/open/floor/plasteel/stairs/medium{
-	dir = 8
-	},
-/area/maintenance/port/aft)
 "nAa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -34674,6 +35991,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/range)
+"nAD" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "nBg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/dark,
@@ -34846,6 +36168,10 @@
 	},
 /turf/open/floor/circuit/off,
 /area/tcommsat/server)
+"nEx" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "nEJ" = (
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
@@ -34973,10 +36299,11 @@
 /turf/closed/wall,
 /area/medical/genetics)
 "nHz" = (
-/obj/structure/table/wood,
-/obj/item/soap/nanotrasen,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nHO" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/structure/window/reinforced{
@@ -35106,9 +36433,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "nJZ" = (
-/obj/structure/sign/poster/contraband/syndicate_pistol,
-/turf/closed/wall,
-/area/ruin/has_grav)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nKb" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35135,9 +36465,6 @@
 /obj/item/storage/pill_bottle/mannitol{
 	pixel_x = 10;
 	pixel_y = -1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -35171,6 +36498,10 @@
 	name = "Medbay";
 	req_access_txt = "5"
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nLB" = (
@@ -35180,6 +36511,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "nLE" = (
@@ -35187,9 +36519,13 @@
 /area/crew_quarters/heads/captain)
 "nLQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "nLV" = (
@@ -35375,14 +36711,22 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/bar)
 "nOA" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
 /area/engine/engineering)
 "nOH" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nOI" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
@@ -35441,6 +36785,18 @@
 /obj/item/camera/detective,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"nPz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "nPB" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -35564,10 +36920,14 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "nRu" = (
-/obj/structure/barricade/wooden,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nRA" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
@@ -35609,10 +36969,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "nSf" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
-/turf/open/floor/engine,
+/obj/machinery/power/emitter/welded,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "nSi" = (
 /obj/structure/table/wood,
@@ -35629,9 +36988,6 @@
 /obj/item/reagent_containers/food/drinks/bottle/applejack{
 	pixel_x = -14;
 	pixel_y = 5
-	},
-/obj/machinery/newscaster{
-	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -35663,15 +37019,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nSS" = (
-/obj/structure/destructible/cult/tome,
-/obj/item/book/codex_gigas,
-/obj/structure/sign/painting/library_private{
-	pixel_y = -32
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/cult,
-/area/library)
 "nSU" = (
 /obj/machinery/conveyor{
 	dir = 8
@@ -35704,9 +37051,14 @@
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
 "nUl" = (
-/obj/structure/fluff/hedge,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nUH" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -35898,6 +37250,8 @@
 "nYv" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/security/main)
 "nYH" = (
@@ -35973,10 +37327,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "oag" = (
-/obj/structure/table/wood/fancy,
-/obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/carpet,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oah" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -36030,13 +37388,20 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "obb" = (
-/obj/machinery/photocopier,
-/obj/item/storage/photo_album/library,
-/obj/structure/sign/painting/library_private{
-	pixel_x = -32
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cult,
-/area/library)
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "obl" = (
 /obj/structure/table,
 /obj/machinery/door/firedoor,
@@ -36086,6 +37451,8 @@
 "obX" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "obZ" = (
@@ -36101,8 +37468,7 @@
 /turf/open/floor/carpet,
 /area/security/main)
 "och" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/asteroid,
 /area/ruin/has_grav)
 "ocq" = (
 /obj/item/storage/backpack/ert/janitor,
@@ -36252,6 +37618,14 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"ofs" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1;
+	name = "Output to Waste"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ofw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1
@@ -36422,15 +37796,8 @@
 /area/maintenance/starboard/aft)
 "oia" = (
 /obj/structure/table,
-/obj/machinery/light,
-/obj/item/gps/engineering{
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/gps/engineering{
-	pixel_x = 5;
-	pixel_y = -5
-	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/item/storage/firstaid/toxin,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oiR" = (
@@ -36614,10 +37981,18 @@
 	},
 /area/hallway/primary/central)
 "olV" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos to Loop"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ome" = (
 /obj/machinery/door/window,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -36649,13 +38024,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "onB" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/west{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Engine"
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "onC" = (
 /obj/structure/closet/secure_closet/engineering_chief,
@@ -36684,30 +38059,10 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"ooz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ooB" = (
-/obj/structure/closet/wardrobe/curator,
-/obj/structure/sign/painting/library_private{
-	pixel_y = 32
-	},
-/obj/structure/sign/painting/library_private{
-	pixel_x = 32
-	},
-/obj/item/tank/jetpack/suit,
-/obj/item/clothing/under/rank/civilian/curator/skirt{
-	pixel_x = -2
-	},
-/obj/item/clothing/under/rank/civilian/curator{
-	pixel_x = 7
-	},
-/obj/item/toy/eightball,
-/obj/item/clothing/shoes/laceup/digitigrade,
-/turf/open/floor/plasteel/cult,
+/obj/structure/table/wood,
+/obj/machinery/computer/bookmanagement,
+/turf/open/floor/wood,
 /area/library)
 "ooI" = (
 /obj/machinery/vending/cigarette,
@@ -36719,6 +38074,12 @@
 "ooX" = (
 /turf/closed/wall,
 /area/medical/storage)
+"opb" = (
+/mob/living/simple_animal/pet/cat/space,
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged3"
+	},
+/area/maintenance/port/aft)
 "opn" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -36798,6 +38159,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"oqv" = (
+/obj/structure/window/spawner,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/maintenance/port/aft)
 "oqz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -36807,6 +38173,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
+"oqA" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oqU" = (
 /obj/structure/sign/picture_frame/showroom/two{
 	pixel_x = -32
@@ -36847,6 +38222,14 @@
 /obj/structure/statue/sandstone/assistant,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"org" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/toy/plush/jone{
+	desc = "Anomalous...";
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "orn" = (
 /turf/open/floor/carpet/orange,
 /area/quartermaster/qm)
@@ -37006,9 +38389,9 @@
 /turf/open/floor/plasteel/white/side,
 /area/hallway/secondary/service)
 "otu" = (
-/obj/item/stack/rods/twentyfive,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "otI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37133,6 +38516,17 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plastic,
 /area/security/brig)
+"ovK" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "ovY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -37232,6 +38626,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"oxB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/wrench,
+/obj/item/screwdriver,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "oxD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37244,16 +38646,16 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "oyb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/turf/open/floor/plasteel/white/side{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oyh" = (
 /obj/structure/table/glass,
@@ -37349,6 +38751,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"ozA" = (
+/obj/structure/closet/crate/radiation,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/engine/engineering)
 "ozB" = (
 /obj/structure/closet{
 	name = "Evidence Closet 2"
@@ -37424,9 +38836,11 @@
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
 "oAq" = (
-/obj/machinery/shieldgen,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
 "oAM" = (
 /turf/closed/indestructible/reinforced,
 /area/security/courtroom)
@@ -37437,13 +38851,10 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
-"oCe" = (
-/obj/structure/table,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+"oBX" = (
+/obj/item/banner/medical,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "oCr" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/requests_console{
@@ -37468,7 +38879,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oCK" = (
-/obj/structure/table/reinforced,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson{
 	pixel_y = 6
@@ -37479,6 +38889,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oCR" = (
@@ -37489,10 +38903,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oCY" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/light,
-/obj/machinery/power/apc/highcap/five_k,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "oCZ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -37612,6 +39026,15 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"oGO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "oGT" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -37720,6 +39143,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
+"oIt" = (
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Aft Port Solar Control";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "oIE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -37931,6 +39365,13 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"oNa" = (
+/obj/machinery/door/poddoor{
+	id = "Tesla Storage";
+	name = "Tesla Storage"
+	},
+/turf/open/floor/plating,
+/area/engine/storage)
 "oNb" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/carpet,
@@ -37976,9 +39417,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "oNB" = (
-/obj/structure/sign/poster/contraband/syndicate,
-/turf/closed/wall,
-/area/ruin/has_grav)
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "oNL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -38008,6 +39451,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/glass/reinforced,
 /area/science/research)
+"oNY" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "oOe" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
@@ -38030,6 +39477,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"oPp" = (
+/obj/structure/lattice,
+/obj/machinery/camera/motion{
+	c_tag = "Gravity Generator External Hull South"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "oPw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
@@ -38057,6 +39511,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"oQd" = (
+/mob/living/simple_animal/hostile/lizard/space{
+	desc = "He has several degrees in astrophysics, advanced engineering, and orbital assembly.";
+	name = "Chief Lizzie"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "oQt" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -38112,10 +39575,16 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/button/door{
-	id = "Tesla Storage";
-	name = "Tesla Storage";
-	pixel_x = 25
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -38251,6 +39720,12 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"oTt" = (
+/obj/item/clothing/under/rank/engineering/signal_tech,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/space/nearstation)
 "oTG" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -38291,9 +39766,14 @@
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
 "oUk" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "oUr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -38333,12 +39813,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"oVc" = (
-/obj/structure/barricade/wooden,
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "oVy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -38352,6 +39826,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms/barracks)
 "oWb" = (
@@ -38381,18 +39856,14 @@
 /turf/open/floor/holofloor/dark,
 /area/science/mixing)
 "oWk" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Solar Access";
-	req_access_txt = "10"
-	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oWr" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Auxiliary Tool Storage";
@@ -38405,13 +39876,7 @@
 /turf/closed/wall,
 /area/crew_quarters/dorms)
 "oXr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side,
 /area/medical/medbay/central)
 "oXw" = (
 /obj/structure/closet/crate{
@@ -38438,19 +39903,6 @@
 /obj/structure/table/wood/fancy,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"oXR" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "oXU" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -38616,6 +40068,11 @@
 "pbo" = (
 /turf/open/floor/plasteel/dark,
 /area/gateway)
+"pbs" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "pbw" = (
 /obj/structure/sign/directions/supply{
 	dir = 8;
@@ -38678,6 +40135,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "pbZ" = (
@@ -38729,12 +40187,18 @@
 	},
 /area/maintenance/starboard/aft)
 "pcE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Tesla Storage";
-	name = "Tesla Storage"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Shared Engineering Storage";
+	req_one_access_txt = "32;19"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "pcR" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -38777,6 +40241,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "pdj" = (
@@ -38810,15 +40276,8 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "pdv" = (
-/obj/structure/rack{
-	icon = 'icons/obj/stationobjs.dmi';
-	icon_state = "minibar";
-	name = "skeletal minibar"
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/wood,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/maintenance/port/aft)
 "pdx" = (
 /obj/structure/disposalpipe/segment{
@@ -38855,13 +40314,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "pdR" = (
-/obj/machinery/power/smes,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
 	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
+"pdZ" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/area/maintenance/port/aft)
 "pet" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 8
@@ -38926,6 +40389,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"pgF" = (
+/obj/structure/barricade/wooden/crude,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/rust,
+/area/ruin/has_grav)
 "pgP" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /obj/effect/turf_decal/trimline/blue,
@@ -38975,7 +40443,7 @@
 	name = "Teleporter Shutters";
 	pixel_x = 26;
 	pixel_y = 6;
-	req_access_txt = "31"
+	req_access_txt = "17"
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -39047,6 +40515,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "pkf" = (
@@ -39091,12 +40560,18 @@
 /area/security/warden)
 "pkF" = (
 /obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
+"pkN" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pkO" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
@@ -39255,10 +40730,6 @@
 /obj/structure/sign/departments/nanites,
 /turf/closed/wall/r_wall,
 /area/science/nanite)
-"pnD" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engine/engineering)
 "pnK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39268,8 +40739,15 @@
 /area/science/lab)
 "pop" = (
 /obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/solar/port/aft)
+/obj/machinery/button/door{
+	id = "radiation shutters";
+	name = "radiation shutters";
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "pos" = (
 /obj/effect/spawner/lootdrop/aimodule_harmless,
 /obj/machinery/door/window/brigdoor{
@@ -39329,14 +40807,6 @@
 /obj/effect/decal/cleanable/greenglow/ecto,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"ppl" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ppx" = (
 /obj/item/target/syndicate,
 /turf/open/floor/engine,
@@ -39365,6 +40835,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -39441,8 +40914,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon/wayfinding/engineering,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"pqU" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 1;
+	filter_type = "n2"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "prg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -39617,6 +41098,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/education)
+"ptD" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/plasteel/cult,
+/area/library)
 "ptJ" = (
 /obj/machinery/light,
 /obj/structure/tank_dispenser/oxygen,
@@ -39669,9 +41157,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/fore)
 "puV" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg2"
+	},
 /area/maintenance/port/aft)
 "puW" = (
 /obj/machinery/door/firedoor,
@@ -39698,6 +41186,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pvg" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "pvK" = (
 /obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
@@ -39760,13 +41252,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "pvL" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Void Technician's Office";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pvN" = (
@@ -39821,9 +41307,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "pwe" = (
-/obj/item/stack/rods/ten,
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "pwk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39952,18 +41437,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "pyx" = (
-/obj/structure/festivus{
-	anchored = 1;
-	layer = 4;
-	name = "pole"
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Engineering Maintenance";
+	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "pyL" = (
 /obj/machinery/pipedispenser,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40014,15 +41502,19 @@
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "pzL" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/solars/port/aft)
 "pzQ" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium/purple,
 /area/janitor)
+"pzU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "pAc" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -40070,6 +41562,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"pAA" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet,
+/area/maintenance/port/aft)
 "pAM" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -40417,9 +41913,13 @@
 /turf/closed/wall/r_wall,
 /area/security/prison/mess)
 "pFB" = (
-/obj/machinery/the_singularitygen/tesla,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
 /area/engine/engineering)
 "pFE" = (
 /obj/structure/chair{
@@ -40475,6 +41975,10 @@
 /obj/item/clothing/gloves/color/plasmaman/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"pGd" = (
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "pGl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -40591,6 +42095,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -40833,6 +42340,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"pMR" = (
+/obj/structure/lattice,
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/engine/engine_room)
 "pNA" = (
 /obj/structure/window/reinforced/spawner/west{
 	dir = 4
@@ -40909,6 +42421,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/main)
 "pOR" = (
@@ -40917,24 +42431,6 @@
 	icon_state = "chapel"
 	},
 /area/chapel/office)
-"pPa" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced/spawner/north,
-/obj/item/gun/energy/disabler{
-	pixel_x = 6;
-	pixel_y = -6
-	},
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "pPe" = (
 /obj/machinery/shower{
 	dir = 8
@@ -41004,7 +42500,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/medical/chemistry)
 "pQh" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -41141,6 +42637,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"pST" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
+/area/medical/medbay/central)
 "pTd" = (
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -41155,15 +42659,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "pTo" = (
-/obj/machinery/shower{
-	pixel_y = 18
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower";
+	pixel_y = -5
 	},
 /turf/open/floor/noslip,
 /area/engine/engineering)
@@ -41180,11 +42682,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"pTB" = (
+/obj/structure/girder,
+/obj/structure/barricade/wooden,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pTD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1;
 	sortType = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -41222,6 +42740,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -41268,9 +42789,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "pUA" = (
-/turf/open/floor/plasteel/stairs/medium{
-	dir = 4
+/obj/structure/table,
+/obj/item/kirbyplants/random{
+	pixel_y = 10
 	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pUB" = (
 /obj/effect/spawner/randomcolavend,
@@ -41384,6 +42907,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"pWk" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pWn" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -41431,9 +42964,11 @@
 /turf/closed/wall/r_wall,
 /area/bridge/meeting_room/council)
 "pWF" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/item/assembly/mousetrap/armed,
-/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pXa" = (
@@ -41465,10 +43000,6 @@
 	},
 /turf/closed/wall,
 /area/medical/medbay/lobby)
-"pXl" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "pXo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41602,14 +43133,17 @@
 /turf/open/floor/plastic,
 /area/security/brig)
 "pZg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/engine/engine_room)
+"pZk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "pZF" = (
 /obj/structure/table/glass,
 /obj/item/clipboard{
@@ -41638,6 +43172,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"pZR" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qaj" = (
 /obj/machinery/door/airlock/vault{
 	name = "Vault Door";
@@ -41690,10 +43234,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "qaJ" = (
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
 	},
+/turf/open/space/basic,
 /area/space/nearstation)
 "qaO" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -41807,6 +43352,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
 "qcQ" = (
@@ -41885,7 +43433,8 @@
 	id = "radiation shutters";
 	name = "radiation shutters";
 	pixel_x = -7;
-	pixel_y = 5
+	pixel_y = 5;
+	req_access_txt = "56"
 	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -41893,22 +43442,14 @@
 	name = "Engineering Lockdown";
 	pixel_x = -7;
 	pixel_y = -5;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door{
-	desc = "A remote control-switch for secure storage.";
-	id = "Secure Storage";
-	name = "Engineering Secure Storage";
-	pixel_x = 7;
-	pixel_y = -5;
-	req_access_txt = "11"
+	req_access_txt = "56"
 	},
 /obj/machinery/button/door{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = 7;
 	pixel_y = 5;
-	req_access_txt = "24"
+	req_access_txt = "56"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -42011,10 +43552,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/sink{
-	layer = 3.1;
-	pixel_y = 20
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "qfB" = (
@@ -42090,21 +43627,6 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall/r_wall,
 /area/medical/pharmacy)
-"qgX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "qhc" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -42156,11 +43678,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"qhD" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "qhL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -42185,6 +43702,15 @@
 /obj/machinery/navbeacon/wayfinding/teleporter,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"qib" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/turf/open/floor/noslip,
+/area/science/xenobiology)
 "qid" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -42331,6 +43857,13 @@
 /obj/structure/disposalpipe/junction,
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"qku" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "qkC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -42396,11 +43929,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "qlp" = (
-/obj/structure/particle_accelerator/particle_emitter/left{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qls" = (
 /obj/structure/table/glass,
@@ -42450,14 +43979,8 @@
 	},
 /area/maintenance/starboard/aft)
 "qmF" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "qmM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/circuit,
@@ -42486,13 +44009,14 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "qnv" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Starboard Solar Access";
-	req_access_txt = "10"
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qnx" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/photocopier{
@@ -42623,6 +44147,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"qpk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qpv" = (
 /obj/item/bedsheet/rd,
 /obj/structure/bed,
@@ -42634,13 +44165,17 @@
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "qpG" = (
-/obj/machinery/camera{
-	c_tag = "Aft Port Solar Control";
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "qqb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -42664,6 +44199,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "qqr" = (
@@ -42672,6 +44210,12 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qqy" = (
@@ -42812,14 +44356,15 @@
 /area/security/main)
 "qtb" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "22;25;26;28;35;37;38;46;70;12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = null;
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70;12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -42857,6 +44402,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "qul" = (
@@ -42884,8 +44430,23 @@
 	name = "Security Maintenance";
 	req_access_txt = "63"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/security/main)
+"quQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "quW" = (
 /obj/structure/chair{
 	dir = 8
@@ -42955,6 +44516,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"qvM" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "qwa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot_white,
@@ -42963,6 +44530,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/crowbar,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "qwg" = (
@@ -42985,6 +44553,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"qwA" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "External Gas to Loop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qwE" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -43042,15 +44620,6 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass,
 /area/hallway/primary/central)
-"qxJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "qyc" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -43100,9 +44669,6 @@
 	},
 /area/chapel/office)
 "qza" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -43163,6 +44729,15 @@
 	},
 /turf/open/floor/plastic,
 /area/medical/medbay/central)
+"qzH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "qzM" = (
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/tile/neutral,
@@ -43182,7 +44757,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "qAh" = (
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qAk" = (
@@ -43402,10 +44979,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "qDN" = (
-/obj/structure/girder,
-/obj/structure/barricade/wooden,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/item/storage/wallet,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "qDS" = (
 /obj/structure/disposalpipe/segment{
@@ -43414,14 +44989,18 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "qEg" = (
-/obj/structure/closet/crate/solarpanel_medium,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table,
+/obj/item/gps/engineering{
+	pixel_x = -5;
+	pixel_y = -5
+	},
+/obj/item/gps/engineering{
+	pixel_x = 5;
+	pixel_y = -5
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qEj" = (
@@ -43604,6 +45183,12 @@
 	dir = 1
 	},
 /area/hallway/secondary/service)
+"qGp" = (
+/obj/structure/table,
+/obj/item/flashlight,
+/obj/item/clothing/head/welding,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "qGt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/red/line{
@@ -43720,20 +45305,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"qHH" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/space/nearstation)
 "qHX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/airalarm/engine{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "qIe" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/robot_debris,
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/item/wrench,
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qIl" = (
@@ -43808,10 +45394,23 @@
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "qIU" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Library Desk";
+	req_access_txt = "37"
+	},
 /turf/open/floor/carpet,
 /area/library)
+"qIV" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "qJm" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -44004,6 +45603,12 @@
 	dir = 1
 	},
 /area/bridge)
+"qLP" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "qLU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -44064,6 +45669,12 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "qMZ" = (
@@ -44275,6 +45886,14 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"qQW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qRp" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -44369,13 +45988,12 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "qTR" = (
-/obj/structure/table/wood,
-/obj/item/cartridge/curator,
-/obj/item/toy/toy_xeno{
-	pixel_x = 14
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
 	},
-/turf/open/floor/carpet,
-/area/library)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qUb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -44399,6 +46017,23 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"qUz" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "External Gas to Loop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"qUB" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "SM shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qUC" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -44457,6 +46092,10 @@
 "qVT" = (
 /turf/open/floor/plasteel/white/side,
 /area/security/prison/rec)
+"qVZ" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "qWd" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/landmark/start/botanist,
@@ -44471,32 +46110,15 @@
 /turf/open/floor/plasteel/white,
 /area/security/main)
 "qWr" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Tesla Storage";
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id_tag = "Tesla Storage";
-	name = "Tesla Storage"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/engine/engineering)
+"qWw" = (
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "qXa" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_y = 32
@@ -44516,16 +46138,26 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "qXF" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/sepia,
-/area/ruin/has_grav)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/manifold/green/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qXJ" = (
 /obj/structure/table/wood,
 /obj/structure/spider/stickyweb,
 /turf/open/floor/carpet,
 /area/vacant_room/office)
+"qXR" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "qYl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -44545,6 +46177,10 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plasteel/white,
 /area/security/main)
+"qYv" = (
+/mob/living/simple_animal/chick,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "qYI" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44633,11 +46269,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rad" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/table/wood/fancy,
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/floor/carpet,
 /area/maintenance/port/aft)
 "raq" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -44837,6 +46471,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"rez" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "reN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -44943,7 +46584,8 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "rgM" = (
-/obj/effect/decal/cleanable/glass,
+/obj/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rgP" = (
@@ -44964,6 +46606,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/toilet)
+"rhm" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white/side{
+	dir = 9
+	},
+/area/engine/engineering)
+"rhq" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "rhs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -44995,6 +46651,21 @@
 /obj/item/screwdriver,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"rhJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "rhL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -45149,7 +46820,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
 /area/hallway/primary/central)
 "rjX" = (
 /obj/structure/table/wood,
@@ -45172,6 +46848,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"rkX" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "rla" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -45435,7 +47118,11 @@
 "rpq" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/north,
-/obj/item/gun/energy/disabler/advanced/pdw,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/gun/energy/disabler,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "rpx" = (
@@ -45516,11 +47203,10 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "rqe" = (
-/obj/structure/table/wood,
-/obj/item/toy/cards/deck,
-/obj/item/clothing/glasses/sunglasses,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/machinery/power/emitter,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/storage)
 "rqh" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/item/clothing/suit/bio_suit/janitor,
@@ -45593,7 +47279,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "rrT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -45669,11 +47355,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "rta" = (
-/obj/effect/landmark/start/voidtech,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -45729,9 +47411,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rtN" = (
-/obj/structure/window/spawner/east,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/asteroid,
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar";
+	name = "skeletal minibar"
+	},
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "rua" = (
 /obj/structure/chair/wood{
@@ -46017,6 +47702,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "rAk" = (
@@ -46112,17 +47803,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rAZ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
-"rBl" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/engine/atmos)
+/obj/machinery/camera/autoname,
+/turf/open/floor/circuit/off,
+/area/tcommsat/server)
 "rBy" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet2";
@@ -46149,6 +47835,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rBR" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "rBX" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -46212,29 +47902,20 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"rDb" = (
+/turf/open/floor/plating/rust,
+/area/ruin/has_grav)
 "rDC" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/wig/random,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
-"rDL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "rEj" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/flora/ausbushes/brflowers{
 	icon_state = "sunnybush_1"
 	},
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/tree/jungle/small{
-	icon_state = "tree4";
-	pixel_x = -16;
-	pixel_y = 16
-	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "rEm" = (
@@ -46470,6 +48151,15 @@
 	dir = 4
 	},
 /area/hallway/primary/central)
+"rHK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/circuit/off,
+/area/tcommsat/server)
 "rHQ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/mineral/titanium/blue,
@@ -46559,6 +48249,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"rJr" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/unres,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "rJt" = (
 /obj/structure/cable,
 /obj/structure/fans/tiny,
@@ -46776,6 +48476,9 @@
 	dir = 5
 	},
 /obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rNE" = (
@@ -46966,9 +48669,8 @@
 /turf/open/floor/wood,
 /area/hydroponics)
 "rRa" = (
-/obj/item/clothing/glasses/meson/engine/tray,
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rRp" = (
@@ -47066,16 +48768,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/office/secretary)
 "rTB" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Gravity Generator";
-	req_access_txt = "11"
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rTC" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -47116,6 +48815,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"rUa" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rUb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -47129,6 +48833,17 @@
 /obj/item/reagent_containers/food/condiment/saltshaker,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"rUi" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "rUj" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rdprivacy";
@@ -47196,8 +48911,20 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rVj" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "rVm" = (
@@ -47229,6 +48956,12 @@
 	},
 /turf/open/floor/plastic,
 /area/security/execution/education)
+"rWk" = (
+/obj/machinery/camera{
+	c_tag = "Engineering West"
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "rWl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -47257,7 +48990,7 @@
 /obj/structure/cable,
 /obj/item/folder/blue,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
+/area/security/checkpoint/customs)
 "rWy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -47317,12 +49050,12 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
-/obj/item/storage/firstaid/toxin{
+/obj/item/storage/firstaid/brute{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/toxin{
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/brute{
 	pixel_x = -3;
 	pixel_y = -3
 	},
@@ -47345,7 +49078,6 @@
 /obj/structure/table/wood,
 /obj/item/toy/katana,
 /obj/item/gun/ballistic/shotgun/toy/crossbow,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/library)
 "rXS" = (
@@ -47355,11 +49087,11 @@
 /turf/open/floor/glass/reinforced,
 /area/medical/chemistry)
 "rYz" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rYD" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -47435,6 +49167,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "rZs" = (
@@ -47551,9 +49284,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "sbb" = (
-/obj/structure/sign/warning/radiation/rad_area,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sbc" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -47568,6 +49304,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
+"sbe" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "sbl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -47600,6 +49343,28 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"sbD" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"sbM" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/supermatter)
+"sbO" = (
+/turf/open/floor/plasteel/cult,
+/area/library)
 "sbZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -47610,6 +49375,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"scl" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "scw" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -47773,6 +49544,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sfy" = (
@@ -47879,6 +49651,7 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/structure/cable,
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
 "sgJ" = (
@@ -47911,16 +49684,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "she" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes/cigpack_robust,
-/obj/item/storage/box/matches{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/item/clothing/mask/cigarette/cigar,
+/obj/machinery/restaurant_portal/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "shf" = (
@@ -48016,6 +49783,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sjZ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ska" = (
 /obj/structure/bed,
 /turf/open/floor/glass/reinforced,
@@ -48027,8 +49799,19 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"ski" = (
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "skx" = (
-/turf/open/space/basic,
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "sky" = (
 /obj/structure/sign/departments/chemistry/pharmacy{
@@ -48133,9 +49916,9 @@
 /area/ruin/has_grav)
 "smn" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/bot_white,
-/obj/structure/closet/l3closet,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white/side{
+	dir = 6
+	},
 /area/medical/medbay/central)
 "smo" = (
 /obj/effect/turf_decal/stripes/line{
@@ -48180,6 +49963,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"smW" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "snm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -48218,11 +50013,6 @@
 /turf/open/floor/glass/reinforced,
 /area/medical/chemistry)
 "snL" = (
-/obj/machinery/door/window/eastleft{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/fire{
 	pixel_x = 3;
@@ -48232,6 +50022,13 @@
 /obj/item/storage/firstaid/fire{
 	pixel_x = -3;
 	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
@@ -48285,15 +50082,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
 "spu" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"spC" = (
-/obj/effect/decal/cleanable/molten_object/large,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "spM" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -48353,6 +50145,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"sqZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "src" = (
 /turf/open/floor/carpet,
 /area/maintenance/starboard/aft)
@@ -48413,6 +50214,11 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"stc" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "stG" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -48535,6 +50341,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"svo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
+"svu" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/structure/fluff/hedge,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "svy" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -48632,11 +50453,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"swl" = (
+/obj/structure/bedsheetbin,
+/obj/structure/table/wood,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "swv" = (
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison/garden)
 "swD" = (
@@ -48778,6 +50608,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"syc" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "syh" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -48816,11 +50650,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "szi" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
 /obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -48845,6 +50680,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"sAn" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "sAE" = (
 /obj/structure/table/reinforced,
 /obj/item/mmi,
@@ -48918,12 +50766,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
-"sBp" = (
-/obj/structure/table,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "sBt" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgery B";
@@ -49280,6 +51122,17 @@
 	},
 /turf/open/floor/circuit,
 /area/tcommsat/server)
+"sGV" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "sHf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -49318,6 +51171,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 5
 	},
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sHy" = (
@@ -49613,10 +51467,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sMB" = (
@@ -49784,6 +51638,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sPa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "sPc" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -49834,10 +51695,8 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "sQu" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "sQD" = (
 /obj/structure/cable,
@@ -49900,11 +51759,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sRd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/item/clothing/head/welding,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sRq" = (
@@ -49915,6 +51770,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sRw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sRz" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
@@ -50046,6 +51907,11 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/crew_quarters/office/secretary)
+"sTb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/robot_suit,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "sTH" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -50458,6 +52324,9 @@
 /area/engine/break_room)
 "tcQ" = (
 /obj/machinery/atmospherics/pipe/simple,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "tdj" = (
@@ -50496,6 +52365,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "tdN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "tdO" = (
@@ -50555,6 +52427,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"teQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "teS" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -50593,9 +52469,7 @@
 	},
 /area/hallway/primary/central)
 "tgf" = (
-/obj/machinery/field/generator,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "tgi" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -50612,11 +52486,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tgw" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = 2;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -50720,13 +52599,24 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
-"tiJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+"tiE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tiJ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tja" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -50769,6 +52659,10 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"tjz" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tjP" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -50814,8 +52708,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tkl" = (
-/obj/effect/landmark/start/voidtech,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50905,6 +52798,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
+"tlL" = (
+/obj/structure/closet/crate/solarpanel_medium,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/engine/engineering)
 "tmc" = (
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101{
 	desc = "Looks like this spider went to culinary school.";
@@ -50952,20 +52858,14 @@
 /obj/machinery/door/airlock/security{
 	name = "Laywers 'Office'"
 	},
+/obj/machinery/door/firedoor,
 /turf/closed/indestructible/reinforced{
 	name = "Lmao stupid"
 	},
 /area/security/courtroom)
 "tmr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/radiation{
-	icon_state = "open";
-	id = "radiation shutters";
-	id_tag = null
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "SM shutters"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -50987,12 +52887,18 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "tmx" = (
-/obj/structure/fluff/hedge,
-/obj/machinery/light/broken{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tmL" = (
+/obj/structure/rack,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "tmS" = (
 /obj/effect/spawner/lootdrop/food_packaging,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -51069,6 +52975,9 @@
 "tnp" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"tnq" = (
+/turf/open/space/basic,
+/area/maintenance/port/aft)
 "tnt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -51076,12 +52985,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "tny" = (
-/obj/structure/table/reinforced,
 /obj/item/pipe_dispenser{
 	pixel_y = 8
 	},
 /obj/item/pipe_dispenser,
-/obj/item/clothing/ears/earmuffs,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tnA" = (
@@ -51172,10 +53083,13 @@
 /area/hallway/primary/central)
 "toD" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/emergency,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 7
+	},
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
+/obj/item/storage/firstaid/emergency,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "toG" = (
@@ -51196,6 +53110,11 @@
 	},
 /turf/closed/wall,
 /area/hallway/primary/port)
+"toV" = (
+/obj/structure/cable,
+/obj/item/taperecorder,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "tpw" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Centcom Office";
@@ -51269,6 +53188,7 @@
 /area/teleporter)
 "tqr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "tqu" = (
@@ -51326,9 +53246,13 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "trr" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/engine,
 /area/engine/engineering)
+"tru" = (
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "trw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -51364,6 +53288,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"tsC" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tsF" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box,
@@ -51417,6 +53346,7 @@
 /obj/machinery/light/small,
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
+/obj/item/crowbar/red,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "tsZ" = (
@@ -51512,6 +53442,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tvB" = (
@@ -51584,11 +53518,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "txa" = (
-/obj/structure/table/wood,
-/obj/item/stack/cable_coil,
-/obj/machinery/light,
-/turf/open/floor/wood,
+/turf/open/floor/plating/airless,
 /area/maintenance/port/aft)
+"txs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "txw" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -51654,6 +53597,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tyr" = (
@@ -51680,10 +53626,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"tyJ" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engine/engine_room)
 "tyM" = (
-/obj/item/stack/sheet/metal/five,
-/turf/open/floor/plasteel/sepia,
-/area/ruin/has_grav)
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Cooling Loop Bypass"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tyW" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -51731,9 +53683,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
 "tAs" = (
-/obj/structure/closet/crate/maint,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tAM" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/camera,
@@ -51793,13 +53747,25 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "tCy" = (
-/obj/machinery/button/door{
-	id = "radiation shutters";
-	name = "radiation shutters";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "SM shutters";
+	name = "emitter shutters";
+	pixel_x = -26;
+	pixel_y = 5;
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = -26;
+	pixel_y = -5;
+	req_access_txt = "10;24"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -51823,13 +53789,6 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "tCR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/construction,
-/obj/item/storage/bag/construction{
-	pixel_y = 4
-	},
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tCW" = (
@@ -51841,6 +53800,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/library)
+"tDg" = (
+/obj/structure/lattice,
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engine/engine_room)
 "tDh" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -51945,7 +53911,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/medical/virology)
 "tFR" = (
 /obj/structure/table,
 /obj/item/training_toolbox{
@@ -52113,6 +54079,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"tIy" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "tID" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52207,10 +54179,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/circuit/green,
 /area/science/nanite)
-"tKr" = (
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet,
-/area/maintenance/port/aft)
+"tKk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "tKt" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -52337,6 +54310,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
+"tLZ" = (
+/obj/structure/particle_accelerator/particle_emitter/right{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "tMj" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -52402,6 +54382,11 @@
 "tMT" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
+"tMY" = (
+/obj/structure/cable,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "tNd" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -52415,6 +54400,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tNK" = (
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tNL" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -52428,6 +54421,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"tNQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tOz" = (
 /obj/item/clothing/shoes/magboots{
 	pixel_x = -4;
@@ -52602,15 +54604,15 @@
 "tQw" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/computer/security,
-/obj/structure/cable,
 /obj/item/radio,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tQA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Desk";
 	req_access_txt = "1"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tQI" = (
@@ -52751,6 +54753,12 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"tSM" = (
+/obj/effect/turf_decal/stripes,
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "tTa" = (
 /obj/structure/reagent_dispensers/foamtank,
 /obj/effect/turf_decal/tile/blue{
@@ -53097,13 +55105,8 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "uao" = (
-/obj/machinery/particle_accelerator/control_box,
-/obj/effect/turf_decal/bot,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/turf/open/floor/engine,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "uar" = (
 /obj/machinery/photocopier,
@@ -53287,12 +55290,12 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ufm" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "ufC" = (
 /obj/structure/cable,
@@ -53309,6 +55312,8 @@
 	dir = 4;
 	id = "packageSort2"
 	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "ufX" = (
@@ -53630,12 +55635,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"ukK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "ulb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -53727,6 +55726,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/white/side,
 /area/hallway/secondary/service)
+"umn" = (
+/obj/structure/particle_accelerator/power_box{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "umM" = (
 /obj/item/soap,
 /obj/item/soap{
@@ -53801,15 +55807,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "unW" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Foyer"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/area/engine/engineering)
 "uob" = (
 /obj/structure/sign/departments/botany{
 	pixel_y = 32
@@ -53945,6 +55950,15 @@
 /obj/item/screwdriver,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
+"upP" = (
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6{
+	pixel_y = 32
+	},
+/obj/item/clothing/suit/xenos,
+/obj/item/clothing/head/xenos,
+/obj/structure/table,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "upZ" = (
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/structure/table,
@@ -53979,8 +55993,17 @@
 	dir = 4
 	},
 /obj/item/ammo_casing/spent,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"uqv" = (
+/obj/structure/table/wood,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "uqA" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -53994,6 +56017,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
+"uqX" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "url" = (
 /obj/structure/table/glass,
 /obj/item/clothing/mask/gas,
@@ -54060,9 +56087,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "urP" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uso" = (
 /obj/structure/disposalpipe/segment{
@@ -54201,12 +56228,7 @@
 /turf/open/floor/glass,
 /area/hallway/primary/central)
 "uuO" = (
-/obj/effect/turf_decal/weather,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/maintenance/port/aft)
 "uuR" = (
 /obj/effect/landmark/start/security_officer,
@@ -54268,6 +56290,7 @@
 	name = "Bar Storage";
 	req_access_txt = "25"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "uvP" = (
@@ -54301,6 +56324,10 @@
 /obj/structure/frame,
 /obj/item/circuitboard/machine/bountypad,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
+"uwx" = (
+/obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "uwD" = (
@@ -54400,6 +56427,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
+"uyw" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/stack/package_wrap,
+/obj/item/wrench,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "uyA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54598,10 +56634,11 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "uCM" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/space/basic,
-/area/solar/port/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "uCX" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -54653,9 +56690,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "uDW" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/weather,
-/obj/structure/cable,
+/obj/structure/bonfire,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uEf" = (
@@ -54679,6 +56714,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uEt" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/carpet,
+/area/library)
 "uEx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -54769,11 +56811,6 @@
 "uFs" = (
 /obj/machinery/medical_kiosk,
 /obj/machinery/light,
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_y = -28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -54796,8 +56833,14 @@
 /turf/open/floor/circuit/off,
 /area/security/nuke_storage)
 "uFR" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/carpet,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uFY" = (
 /obj/machinery/computer/security/telescreen{
@@ -54814,10 +56857,14 @@
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "uFZ" = (
-/obj/effect/landmark/start/librarian,
-/obj/structure/chair/wood,
-/turf/open/floor/plasteel/cult,
-/area/library)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uGf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54854,6 +56901,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
+"uGv" = (
+/obj/structure/table,
+/obj/item/tank/internals/plasma,
+/obj/item/tank/internals/plasma{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uGH" = (
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/disposalpipe/segment,
@@ -54984,6 +57041,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
+"uJa" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "SM shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "uJd" = (
 /obj/structure/bookcase,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -55073,6 +57137,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"uLc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/radiation{
+	icon_state = "open";
+	id = "radiation shutters";
+	id_tag = null
+	},
+/turf/open/floor/plating,
+/area/engine/engine_room)
 "uLn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -55117,13 +57196,10 @@
 /turf/open/floor/plasteel/white/side,
 /area/medical/medbay/lobby)
 "uLN" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/reinforced/spawner{
-	dir = 4
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "backup power monitoring console"
 	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uLP" = (
@@ -55209,8 +57285,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "uNm" = (
-/obj/item/storage/wallet,
-/turf/open/floor/plasteel/dark,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil{
+	amount = 7;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uNr" = (
 /obj/structure/cable,
@@ -55359,15 +57440,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"uOW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "misclab";
-	name = "test chamber blast door"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "uPa" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -55383,6 +57455,15 @@
 	dir = 8
 	},
 /area/science/research)
+"uPd" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uPq" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/siding/wood,
@@ -55540,7 +57621,6 @@
 /turf/open/floor/carpet/red,
 /area/security/brig)
 "uQT" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -55593,7 +57673,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/atmos)
 "uSk" = (
 /turf/closed/wall,
 /area/ruin/has_grav)
@@ -55652,6 +57732,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "uSQ" = (
@@ -55871,6 +57952,15 @@
 "uVT" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"uVX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uWg" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/girder/reinforced,
@@ -55930,6 +58020,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uXM" = (
@@ -55948,6 +58039,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uYc" = (
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "uYj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -55963,14 +58058,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "uYo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56074,6 +58171,7 @@
 "vaB" = (
 /obj/structure/table/reinforced,
 /obj/item/extinguisher/mini,
+/obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "vaX" = (
@@ -56095,6 +58193,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vbl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "vbr" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -56143,7 +58248,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vca" = (
-/turf/open/floor/wood,
+/obj/machinery/recharge_station,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "vce" = (
 /obj/item/bedsheet/centcom,
@@ -56176,6 +58283,13 @@
 	dir = 1
 	},
 /area/quartermaster/office)
+"vcR" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "vcT" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/disposalpipe/segment,
@@ -56206,6 +58320,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"vdo" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "vdt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -56231,11 +58354,14 @@
 /area/engine/atmos)
 "vdK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -56291,11 +58417,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "veV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "vff" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
@@ -56328,6 +58454,13 @@
 /obj/structure/window/spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vfT" = (
+/obj/machinery/door/morgue{
+	name = "Private Study";
+	req_access_txt = "37"
+	},
+/turf/open/space/basic,
+/area/library)
 "vfX" = (
 /obj/machinery/microwave,
 /obj/structure/table/glass,
@@ -56350,6 +58483,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vgn" = (
@@ -56395,13 +58534,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "vgP" = (
-/obj/structure/grille,
-/obj/structure/window{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vgU" = (
 /obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/dark,
@@ -56427,15 +58564,29 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"vic" = (
-/obj/effect/turf_decal/stripes/corner{
+"vhI" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/circuit/green,
 /area/engine/gravity_generator)
+"vic" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "vii" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -56444,7 +58595,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "vij" = (
@@ -56550,13 +58700,13 @@
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "vjt" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plasteel/stairs/medium{
-	dir = 8
-	},
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vju" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -56585,9 +58735,6 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/camera{
-	c_tag = "Library North"
-	},
 /turf/open/floor/wood,
 /area/library)
 "vjV" = (
@@ -56600,6 +58747,9 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -56617,13 +58767,6 @@
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/off,
 /area/tcommsat/server)
-"vkQ" = (
-/obj/machinery/camera/motion{
-	c_tag = "Gravity Generator External Hull West";
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "vkS" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -56658,8 +58801,10 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "vlB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/space/nearstation)
 "vmd" = (
 /obj/structure/table/wood,
@@ -56689,6 +58834,14 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"vmL" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Solar Access";
+	req_access_txt = "10"
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "vmR" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm{
@@ -56724,6 +58877,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
+"vnj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "vnu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -56763,7 +58928,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "vnJ" = (
-/obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -56930,6 +59094,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"vre" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "vrk" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
@@ -57024,10 +59195,7 @@
 /turf/open/floor/carpet/green,
 /area/crew_quarters/dorms)
 "vsN" = (
-/obj/item/toy/plush/jone{
-	pixel_y = 8
-	},
-/obj/structure/table/wood/fancy/red,
+/obj/item/chair/stool,
 /turf/open/floor/plasteel/sepia,
 /area/ruin/has_grav)
 "vsP" = (
@@ -57136,6 +59304,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"vuz" = (
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 1;
+	name = "Output Release"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "vuQ" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Secretary's Office";
@@ -57217,7 +59395,8 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
-	req_access_txt = "22;25;26;28;35;37;38;46;70;12"
+	req_access_txt = null;
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70;12"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
@@ -57277,6 +59456,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"vzy" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "vzz" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "8"
@@ -57333,10 +59521,12 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "vAO" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/cigarettes,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vBb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -57397,15 +59587,16 @@
 /turf/open/floor/plating,
 /area/medical/morgue)
 "vBV" = (
-/obj/machinery/power/emitter,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"vBX" = (
-/obj/machinery/camera{
-	c_tag = "Engineering West"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/turf/open/floor/engine,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"vBX" = (
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "vCa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57490,6 +59681,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
+"vEy" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vEB" = (
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -57522,6 +59721,11 @@
 "vEZ" = (
 /turf/open/floor/wood,
 /area/hallway/primary/port)
+"vFi" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "vFu" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -57714,19 +59918,23 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "vHz" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_one_access_txt = "10;24"
 	},
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "vHB" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
 /area/engine/engineering)
 "vHD" = (
 /obj/structure/sign/directions/command{
@@ -57739,10 +59947,8 @@
 /turf/closed/wall,
 /area/maintenance/central)
 "vHZ" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "vIq" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light{
@@ -57796,11 +60002,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "vJe" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/area/space/nearstation)
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "vJh" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -57810,10 +60016,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"vJq" = (
+/obj/machinery/power/emitter,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"vJQ" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
+/area/engine/engine_room)
 "vKq" = (
-/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/cable,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "vKw" = (
 /obj/effect/turf_decal/delivery,
@@ -57868,10 +60089,6 @@
 /area/hallway/primary/central)
 "vLd" = (
 /obj/item/toy/plush/narplush,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
 /area/library)
@@ -57933,6 +60150,12 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"vLK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "vLN" = (
 /obj/item/storage/bag/tray,
 /obj/item/storage/bag/tray{
@@ -58084,6 +60307,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
+"vOo" = (
+/obj/structure/cable,
+/obj/item/wrench,
+/obj/item/weldingtool,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "vOt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/siding/wood{
@@ -58280,6 +60509,7 @@
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "vRB" = (
@@ -58331,6 +60561,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "vRW" = (
@@ -58340,6 +60571,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "vSf" = (
@@ -58353,8 +60585,12 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "vSv" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vSN" = (
@@ -58375,11 +60611,15 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "vST" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Cooling Loop to Gas"
 	},
-/turf/open/floor/carpet,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "vTq" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -58435,11 +60675,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "vUe" = (
-/obj/structure/particle_accelerator/fuel_chamber{
-	dir = 8
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "vUo" = (
 /obj/structure/table,
@@ -58599,7 +60840,11 @@
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
 "vYd" = (
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "vYe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -58862,9 +61107,38 @@
 /area/maintenance/disposal)
 "wbU" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
+"wbV" = (
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/solars/port/aft)
+/area/engine/supermatter)
+"wcf" = (
+/obj/item/weldingtool,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/engine/engine_room)
+"wch" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5
+	},
+/turf/open/floor/plating,
+/area/engine/gravity_generator)
 "wcn" = (
 /obj/structure/chair{
 	dir = 1
@@ -59002,8 +61276,14 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "weq" = (
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "weD" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -59029,6 +61309,16 @@
 /obj/item/electronics/airalarm,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"weW" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wfc" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -59065,6 +61355,14 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"wgf" = (
+/obj/item/analyzer,
+/obj/structure/rack,
+/obj/item/analyzer{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "wgy" = (
 /obj/machinery/computer/rdconsole{
 	dir = 4
@@ -59218,9 +61516,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wkf" = (
-/obj/item/clothing/head/bearpelt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "wkg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -59281,7 +61579,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/crew_quarters/dorms)
+"wlv" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/circuit/green,
+/area/engine/gravity_generator)
 "wlA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -59302,6 +61604,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"wmm" = (
+/obj/item/clothing/head/bearpelt,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "wmo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -59392,10 +61698,11 @@
 	},
 /area/security/courtroom)
 "wnt" = (
-/obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "wnC" = (
 /obj/effect/turf_decal/siding/wood{
@@ -59448,6 +61755,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/item/toy/figure/atmos{
+	pixel_y = 17
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "wnW" = (
@@ -59473,12 +61783,10 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "woy" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "woK" = (
@@ -59533,6 +61841,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"wqq" = (
+/turf/open/floor/carpet,
+/area/maintenance/port/aft)
+"wqs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/sepia,
+/area/ruin/has_grav)
 "wqy" = (
 /obj/structure/chair{
 	dir = 8
@@ -59592,6 +61909,7 @@
 	id = "briggate";
 	name = "security shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/brig)
 "wrH" = (
@@ -59623,6 +61941,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plastic,
 /area/medical/surgery)
+"wrV" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/robot_debris,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wrW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -59687,6 +62012,9 @@
 /turf/open/floor/plating,
 /area/bridge)
 "wsT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wsV" = (
@@ -59720,6 +62048,11 @@
 	dir = 8
 	},
 /area/security/courtroom)
+"wtq" = (
+/obj/machinery/power/floodlight,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "wtv" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -59779,6 +62112,20 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plastic,
 /area/medical/medbay/central)
+"wtV" = (
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Foyer"
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "wtX" = (
 /obj/structure/table,
 /obj/item/storage/bag/ore,
@@ -59940,23 +62287,20 @@
 	},
 /area/maintenance/starboard/aft)
 "wwd" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/closet/secure_closet/medical3,
+/obj/item/storage/belt/medical{
+	pixel_y = 2
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/storage/belt/medical{
+	pixel_y = 2
 	},
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/brute{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/pinpointer/crew,
+/obj/item/defibrillator,
+/obj/item/sensor_device,
+/turf/open/floor/plasteel/white,
 /area/medical/storage)
 "wwk" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -59978,18 +62322,6 @@
 /obj/item/grown/bananapeel,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"wwA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/circuit/green,
-/area/engine/gravity_generator)
 "wwL" = (
 /obj/structure/railing{
 	dir = 10
@@ -60071,7 +62403,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
@@ -60126,9 +62458,8 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "wyN" = (
-/obj/machinery/suit_storage_unit,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "wyP" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -60204,10 +62535,20 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "wAh" = (
-/obj/structure/closet/emcloset{
-	anchored = 1
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "wAi" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -60369,6 +62710,10 @@
 /area/engine/break_room)
 "wCs" = (
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wCt" = (
@@ -60425,11 +62770,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "wDw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "wDH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -60458,9 +62802,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "wEj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/gravity_generator)
+/obj/item/clothing/mask/facehugger/toy,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wEq" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L5"
@@ -60819,6 +63163,25 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"wKL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"wKN" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "wLb" = (
 /obj/structure/chair{
 	dir = 4
@@ -60865,9 +63228,10 @@
 /area/medical/medbay/lobby)
 "wLV" = (
 /obj/structure/table,
-/obj/item/multitool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "wMf" = (
@@ -60913,14 +63277,22 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "wMQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wNj" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/vending/boozeomat/all_access,
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "wNr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -60930,8 +63302,8 @@
 	},
 /area/medical/medbay/central)
 "wNt" = (
-/obj/effect/turf_decal/bot_white,
 /obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wNx" = (
@@ -60980,6 +63352,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
+"wOd" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/stairs/medium{
+	dir = 8
+	},
+/area/maintenance/port/aft)
 "wOn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -61055,9 +63435,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "wOW" = (
-/obj/effect/turf_decal/weather,
-/turf/open/floor/plating/rust,
-/area/ruin/has_grav)
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Filter"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "wPe" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos)
@@ -61094,10 +63477,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "wPn" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/turf/open/floor/plasteel/solarpanel,
-/area/solar/port/aft)
+/turf/open/space/basic,
+/area/engine/engine_room)
 "wPt" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -61160,6 +63541,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "wQq" = (
@@ -61222,6 +63606,14 @@
 "wRA" = (
 /turf/closed/wall/mineral/titanium,
 /area/crew_quarters/office/secretary)
+"wRD" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"wRP" = (
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "wRU" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
@@ -61233,8 +63625,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -61298,9 +63691,12 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "wTW" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "wUg" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/research_and_development,
@@ -61655,11 +64051,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"xaG" = (
-/obj/item/stack/cable_coil,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xaP" = (
 /obj/structure/chair{
 	dir = 8
@@ -61745,9 +64136,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xbM" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/solar/port/aft)
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/engine,
+/area/engine/engine_room)
+"xbW" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xcd" = (
 /obj/effect/spawner/structure/window/hollow/middle{
 	dir = 4
@@ -61764,9 +64164,29 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"xcm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xcy" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xcA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -61880,15 +64300,6 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"xeO" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/noslip,
-/area/science/xenobiology)
 "xfd" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -61903,6 +64314,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "xfr" = (
@@ -61950,6 +64362,19 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"xfZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/geiger_counter,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xgb" = (
 /obj/structure/cable,
 /obj/machinery/requests_console{
@@ -62023,6 +64448,22 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
 /area/medical/medbay/central)
+"xhp" = (
+/obj/structure/closet/wardrobe/curator,
+/obj/structure/sign/painting/library_private{
+	pixel_y = 32
+	},
+/obj/item/tank/jetpack/suit,
+/obj/item/clothing/under/rank/civilian/curator/skirt{
+	pixel_x = -2
+	},
+/obj/item/clothing/under/rank/civilian/curator{
+	pixel_x = 7
+	},
+/obj/item/toy/eightball,
+/obj/item/clothing/shoes/laceup/digitigrade,
+/turf/open/floor/plasteel/cult,
+/area/library)
 "xhx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -62164,6 +64605,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
+"xjM" = (
+/obj/structure/particle_accelerator/end_cap{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/engine/engine_room)
 "xjZ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -62207,6 +64655,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "xlA" = (
@@ -62255,6 +64704,11 @@
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/office/secretary)
+"xmw" = (
+/turf/open/floor/plasteel/airless{
+	icon_state = "damaged5"
+	},
+/area/maintenance/port/aft)
 "xmU" = (
 /obj/machinery/computer/message_monitor,
 /turf/open/floor/mineral/titanium/white,
@@ -62386,6 +64840,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xpE" = (
@@ -62632,10 +65087,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms/barracks)
-"xtA" = (
-/mob/living/simple_animal/chick,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
 "xtB" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -62651,10 +65102,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xtT" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -62710,6 +65166,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"xvB" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Coolant Bypass"
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xvC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -62815,10 +65281,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "xxI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "xxL" = (
 /mob/living/carbon/human/species/monkey,
@@ -63104,6 +65568,12 @@
 "xDp" = (
 /turf/closed/wall,
 /area/storage/emergency/port)
+"xDu" = (
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/space/nearstation)
 "xDv" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/assistant,
@@ -63115,6 +65585,12 @@
 "xDA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xDJ" = (
@@ -63189,6 +65665,13 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/dorms)
+"xFn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xFw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -63381,10 +65864,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "xIz" = (
-/obj/machinery/light/small{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xIH" = (
@@ -63441,6 +65927,9 @@
 	dir = 5
 	},
 /obj/item/toy/figure/bartender,
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "xJk" = (
@@ -63457,6 +65946,21 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/meeting_room)
+"xJD" = (
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = -26;
+	req_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xJL" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -63521,14 +66025,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "xLF" = (
-/obj/structure/safe,
-/obj/item/clothing/under/syndicate/tacticool/skirt,
-/obj/item/clothing/under/syndicate/tacticool,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
-/obj/item/crowbar/syndie{
-	desc = "There used to be huge fields of these used to mark out shuttle landing zones, now only 1 remains.";
-	name = "The last crowbar"
+/obj/structure/sign/poster/contraband/syndicate{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/sepia,
 /area/ruin/has_grav)
@@ -63616,8 +66114,8 @@
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "xME" = (
-/obj/structure/window/spawner,
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/airlock/wood/glass,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xMF" = (
@@ -63738,19 +66236,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "xOB" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "xOG" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Evidence Storage";
@@ -63817,9 +66310,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xPt" = (
-/obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engine_room)
 "xPB" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -63840,11 +66333,18 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"xQP" = (
-/obj/structure/grille,
+"xQF" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"xQP" = (
+/turf/closed/wall/r_wall,
+/area/engine/engine_room)
 "xRc" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel Hall"
@@ -63873,6 +66373,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"xRF" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "xRJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -63944,6 +66453,16 @@
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
+"xSx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "xSG" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -64099,10 +66618,16 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "xVm" = (
-/obj/structure/window/spawner,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/cable,
-/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xVt" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "xVw" = (
 /obj/effect/turf_decal/tile/blue,
@@ -64311,6 +66836,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xYH" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/aft)
 "xYV" = (
 /obj/machinery/light{
 	dir = 4
@@ -64383,16 +66915,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room/council)
-"xZO" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "yaa" = (
 /obj/structure/bookcase{
 	name = "Holy Bookcase"
@@ -64430,6 +66952,21 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"yap" = (
+/obj/structure/barricade/wooden,
+/obj/effect/spawner/structure/window/hollow/middle,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"yaq" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"yat" = (
+/turf/open/floor/circuit/off,
+/area/engine/gravity_generator)
 "yay" = (
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/plasteel/dark,
@@ -64453,18 +66990,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "yaW" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_one_access_txt = "10;24"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "ybh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -64525,8 +67058,12 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "ych" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/obj/machinery/light,
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ycp" = (
 /obj/effect/turf_decal/stripes/line,
@@ -64603,11 +67140,23 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"ydv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ydH" = (
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ydP" = (
-/turf/open/floor/engine,
+/obj/machinery/power/emitter/welded,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ydY" = (
 /obj/structure/cable,
@@ -64626,9 +67175,12 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "yei" = (
-/obj/structure/bonfire,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "yem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -64707,6 +67259,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "yfj" = (
@@ -64768,6 +67321,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ygr" = (
+/obj/item/stack/spacecash/c1{
+	pixel_y = -6
+	},
+/obj/item/stack/spacecash/c1{
+	pixel_x = 16;
+	pixel_y = 10
+	},
+/obj/item/stack/spacecash/c1{
+	pixel_x = 10
+	},
+/obj/item/stack/spacecash/c1{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "ygu" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -64896,6 +67466,17 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yih" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"yio" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "yir" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -65095,6 +67676,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
+"ykD" = (
+/obj/effect/decal/cleanable/molten_object/large,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "ykL" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
@@ -65171,8 +67756,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "ylK" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Gas to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ylQ" = (
 /turf/open/floor/engine,
@@ -73799,6 +76390,7 @@ fMK
 fMK
 fMK
 fMK
+xTL
 fMK
 fMK
 fMK
@@ -73863,8 +76455,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
-fMK
+xTL
 fMK
 fMK
 fMK
@@ -74588,7 +77179,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -74843,6 +77434,9 @@ fMK
 fMK
 fMK
 fMK
+pWw
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -74852,10 +77446,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -75102,6 +77693,7 @@ fMK
 fMK
 fMK
 fMK
+pWw
 fMK
 fMK
 fMK
@@ -75111,12 +77703,11 @@ fMK
 fMK
 fMK
 fMK
+pWw
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -75359,26 +77950,26 @@ fMK
 fMK
 fMK
 fMK
+pWw
+pWw
 fMK
 fMK
 fMK
+pWw
 fMK
 fMK
 fMK
+pWw
+pWw
+fMK
+fMK
+pWw
+pWw
+pWw
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -75616,27 +78207,27 @@ fMK
 fMK
 fMK
 fMK
+pWw
 fMK
 fMK
 fMK
 fMK
+pWw
+fMK
+fMK
+pWw
+pWw
+nFm
+nFm
+bOD
+pWw
+pWw
 fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -75873,37 +78464,37 @@ fMK
 fMK
 fMK
 fMK
+nFm
+nFm
+pWw
+pWw
+fMK
+pWw
+fMK
+fMK
+fMK
+pWw
+pWw
+fMK
+fMK
+fMK
+pWw
+fMK
+fMK
+fMK
+fMK
+pWw
+fMK
+fMK
+pWw
+pWw
 fMK
 fMK
 fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -76129,6 +78720,38 @@ fMK
 fMK
 fMK
 fMK
+nFm
+nFm
+xCA
+fMK
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+pWw
+pWw
+pWw
+fMK
+fMK
+fMK
+pWw
+fMK
+pWw
+fMK
+fMK
+fMK
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -76145,41 +78768,9 @@ fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+nFm
+nFm
+nFm
 fMK
 fMK
 fMK
@@ -76385,6 +78976,47 @@ fMK
 fMK
 xTL
 fMK
+pWw
+nFm
+xCA
+xCA
+pWw
+nFm
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+xCA
+nFm
+fMK
+fMK
+pWw
+fMK
+pWw
+pWw
+pWw
+pWw
+pWw
+fMK
+fMK
+fMK
+fMK
+pWw
+fMK
+fMK
+fMK
+pWw
+fMK
+fMK
+fMK
+xTL
 fMK
 fMK
 fMK
@@ -76392,52 +79024,11 @@ fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+nFm
+nFm
+pWw
+nFm
+nFm
 fMK
 fMK
 fMK
@@ -76640,6 +79231,45 @@ fMK
 fMK
 fMK
 fMK
+pWw
+fMK
+pWw
+fMK
+fMK
+pWw
+fMK
+nFm
+xCA
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+nFm
+xCA
+nFm
+pWw
+nFm
+nFm
+nFm
+pWw
+fMK
+fMK
+fMK
+nFm
+nFm
+pWw
+pWw
+nFm
+nFm
+pWw
+pWw
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -76650,59 +79280,20 @@ fMK
 fMK
 fMK
 fMK
+nFm
+nFm
+fMK
+pWw
+fMK
+nFm
+nFm
 fMK
 fMK
 fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+xTL
 fMK
 fMK
 fMK
@@ -76896,67 +79487,67 @@ fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
+pWw
+pWw
+pWw
+nFm
+xCA
+nFm
 fMK
 nFm
 nFm
 nFm
+pWw
+fMK
+mna
+qaJ
+mna
+qaJ
+fMK
+pWw
+nFm
+nFm
+nFm
+fMK
+nFm
+xCA
+nFm
+pWw
+fMK
+fMK
+fMK
+pWw
+fMK
+fMK
+fMK
+fMK
+pWw
+fMK
+fMK
+fMK
+pWw
 fMK
 fMK
 fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
+pWw
+nFm
+nFm
+nFm
+pWw
+pWw
+aLw
+pWw
+pWw
+nFm
+nFm
+nFm
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -77154,11 +79745,31 @@ fMK
 fMK
 fMK
 fMK
+pWw
+fMK
+fMK
+nFm
+xCA
+nFm
 fMK
 fMK
 fMK
+pWw
+mna
+qaJ
+kSk
+kSk
+kSk
+kSk
+mna
+qaJ
+pWw
 fMK
 fMK
+fMK
+nFm
+xCA
+nFm
 fMK
 fMK
 fMK
@@ -77168,7 +79779,9 @@ fMK
 fMK
 fMK
 fMK
+pWw
 fMK
+pWw
 fMK
 pWw
 fMK
@@ -77176,44 +79789,22 @@ fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-xTL
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-nFm
-nFm
 pWw
 nFm
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
+iYN
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
 nFm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -77411,14 +80002,43 @@ pWw
 fMK
 fMK
 fMK
+pWw
 fMK
 fMK
+nFm
+xCA
+nFm
+pWw
+pWw
+kmT
+lBI
+kSk
+kSk
+kSk
+kSk
+kSk
+kSk
+kSk
+kSk
+kmT
+lBI
+pWw
+pWw
+nFm
+xCA
+nFm
 fMK
 fMK
+pWw
 fMK
+pWw
+nFm
+nFm
+nFm
+nFm
+nFm
 fMK
-fMK
-fMK
+pWw
 fMK
 pWw
 fMK
@@ -77426,52 +80046,23 @@ fMK
 fMK
 fMK
 pWw
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 nFm
 nFm
 fMK
-pWw
+kxs
+kxs
+kxs
+kxs
+fMK
+iYN
+fMK
+kxs
+kxs
+kxs
+kxs
 fMK
 nFm
 nFm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -77667,70 +80258,70 @@ fMK
 pWw
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
 pWw
 fMK
 fMK
+nFm
+xCA
+nFm
+fMK
+fMK
+kAj
+kAj
+kAj
+kAj
+kAj
+nia
+kAj
+kAj
+nia
+kAj
+kAj
+kAj
 fMK
 fMK
 pWw
-fMK
-fMK
-fMK
-fMK
 pWw
-fMK
-pWw
-fMK
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 pWw
 pWw
 nFm
 nFm
 nFm
+nFm
+nFm
+xCA
+xCA
+xCA
+nFm
+nFm
+nFm
+nFm
+nFm
 pWw
 pWw
-hOO
 pWw
 pWw
 nFm
 nFm
+pWw
+pWw
+iYN
+iYN
+iYN
+iYN
+iYN
+glp
+iYN
+iYN
+iYN
+iYN
+iYN
+pWw
+pWw
+nFm
 nFm
 pWw
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -77929,65 +80520,65 @@ nFm
 fMK
 nFm
 nFm
+xCA
 nFm
 nFm
-nFm
-nFm
-nFm
-nFm
-nFm
+pWw
+kAj
+kAj
+nia
+kAj
+kAj
+nia
+kAj
+kAj
+nia
+kAj
+kAj
+nia
 fMK
 fMK
-nFm
-nFm
-nFm
-nFm
-nFm
-nFm
-nFm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+arJ
+xCA
 nFm
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-uCM
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+nFm
+xCA
+xCA
+xCA
+pWw
+nFm
+pWw
+nFm
+pWw
+xCA
+xCA
+xCA
 nFm
 fMK
 fMK
 fMK
+pWw
+fMK
+fMK
+fMK
+fMK
+kxs
+kxs
+kxs
+kxs
+fMK
+glp
+fMK
+kxs
+kxs
+kxs
+kxs
 fMK
 fMK
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-xTL
 fMK
 fMK
 fMK
@@ -78188,57 +80779,57 @@ nFm
 xCA
 xCA
 xCA
-xCA
-xCA
-xCA
+sQZ
+fMK
+kAj
+kAj
+nia
+kAj
+kAj
+nia
+kAj
+kAj
+nia
+kAj
+kAj
+nia
+pWw
+vre
+bzM
 xCA
 nFm
 pWw
+pWw
 fMK
-nFm
-xCA
-xCA
-xCA
-xCA
-xCA
-nFm
+pWw
+pWw
+fMK
+pWw
+fMK
+pWw
+fMK
+pWw
+pWw
+fMK
+pWw
+pWw
 fMK
 fMK
 pWw
-nFm
-nFm
-nFm
 fMK
 fMK
 fMK
 fMK
 fMK
+pWw
 fMK
+pWw
 fMK
+glp
 fMK
-nFm
-nFm
+pWw
 fMK
-wPn
-wPn
-wPn
-wPn
-fMK
-uCM
-fMK
-wPn
-wPn
-wPn
-wPn
-fMK
-nFm
-nFm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -78447,61 +81038,61 @@ pWw
 pWw
 pWw
 pWw
+kAj
+kAj
+nia
+kAj
+kAj
+vAO
+sbb
+lXW
+nnT
+lXW
+sbb
+nia
 fMK
-fMK
-pWw
-pWw
-pWw
-fMK
-fMK
-pWw
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-pWw
 xCA
+ieX
 xCA
-nFm
-nFm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-nFm
-nFm
 pWw
 pWw
-uCM
-uCM
-uCM
-uCM
-uCM
-moO
-uCM
-uCM
-uCM
-uCM
-uCM
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
+xQP
 pWw
 pWw
-nFm
-nFm
+fMK
+qnS
+fMK
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+fMK
+glp
+fMK
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+fMK
 pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -78696,7 +81287,7 @@ pWw
 fMK
 pWw
 pWw
-fMK
+hQS
 hdz
 pWw
 fMK
@@ -78704,65 +81295,65 @@ pWw
 fMK
 pWw
 fMK
+kAj
+lXW
+nnT
+lXW
+sbb
+vBV
+sjZ
+sjZ
+lHN
+sjZ
+sjZ
+nnT
 fMK
-fMK
+aRD
+lVt
+mHT
 pWw
+xQP
+xQP
+xPt
+xPt
+xPt
+xPt
+xPt
+xPt
+xPt
+xPt
+xPt
+xPt
+xPt
+xQP
+xQP
 pWw
-pWw
-pWw
-pWw
-pWw
-fMK
-pWw
-pWw
-fMK
-fMK
-pWw
-pWw
-fMK
-xCA
-xCA
 nFm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-wPn
-wPn
-wPn
-wPn
-fMK
-moO
-fMK
-wPn
-wPn
-wPn
-wPn
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+nFm
+pWw
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+glp
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+pWw
+pWw
+pWw
+pWw
+qnS
+qnS
 fMK
 fMK
 fMK
@@ -78961,66 +81552,66 @@ rPG
 rPG
 rPG
 rPG
-fMK
-fMK
+kAj
+pWw
 xDJ
 xDJ
+xxI
+vJe
+xxI
+xxI
 xDJ
+xxI
+xxI
 xDJ
+xxI
 xDJ
-xDJ
-xDJ
-xDJ
-xDJ
-xDJ
-xDJ
-xDJ
-xDJ
-fMK
-fMK
+sAn
+xCA
+pWw
+xQP
+xPt
+xQP
+tyJ
+wPn
+aIK
+aIK
+wtq
+aIK
+aIK
+wPn
+tyJ
+xQP
+xPt
+xQP
+pWw
 xCA
 nFm
 fMK
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
 fMK
+glp
 fMK
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
 fMK
 fMK
 pWw
 fMK
 fMK
-fMK
-fMK
-fMK
 pWw
-fMK
 pWw
-fMK
-moO
-fMK
-pWw
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+qnS
 fMK
 fMK
 fMK
@@ -79218,66 +81809,66 @@ wXJ
 uXr
 wXJ
 rPG
-pWw
+kSk
 xDJ
 xDJ
-ylK
-ylK
-ylK
-ylK
-ylK
+cem
+tmx
+vST
+sRw
+sRw
+tmx
+sRw
+sRw
+sRw
+tmx
+ydv
+mBe
 xDJ
-ylK
-ylK
-ylK
-ylK
-ylK
-xDJ
-xDJ
-pWw
-pWw
-pWw
+arJ
+xQP
+xPt
+wPn
+tyJ
+aIK
+wPn
+tKk
+wRP
+tKk
+wPn
+pMR
+tyJ
+wPn
+xPt
+xQP
 fMK
+xCA
+nFm
 fMK
-fMK
-fMK
-fMK
-qnS
-fMK
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-fMK
-moO
-fMK
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
 fMK
 pWw
 fMK
 fMK
 fMK
+pWw
+fMK
+fMK
+glp
+fMK
+fMK
+pWw
 fMK
 fMK
 fMK
 fMK
 fMK
+xTL
+pWw
+pWw
 fMK
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -79475,62 +82066,62 @@ wXJ
 tUX
 wXJ
 rPG
-tWR
-xDJ
+kVh
+lZd
 ylK
-xDJ
-skx
-pnD
-skx
-nkq
+qnv
+tyM
+wDw
+pqU
+iyn
 cgf
-nkq
-skx
-pnD
-skx
-xDJ
-ylK
-xDJ
-pWw
+iyn
+cgf
+iyn
+cgf
+uPd
+vuz
+dwA
+tIy
+xQP
+xPt
+tyJ
+qmF
+qmF
+wPn
+aIK
+wRP
+aIK
+wPn
+qmF
+qmF
+tyJ
+xPt
+xQP
 fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-pWw
-pWw
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-moO
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-pWw
-pWw
-pWw
-pWw
-qnS
+xCA
 qnS
 fMK
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+fMK
+glp
+fMK
+kxs
+kxs
+kxs
+kxs
+lxq
+pWw
 fMK
 fMK
 fMK
-fMK
-fMK
-fMK
+pWw
 fMK
 fMK
 fMK
@@ -79733,62 +82324,62 @@ wXJ
 hSh
 rPG
 tWR
-xDJ
-ylK
+xxI
+nHz
 iQM
-skx
-pnD
-skx
+tAs
+tAs
+vdo
 dPW
-nkq
-skx
-skx
-pnD
-skx
-iQM
-ylK
-xDJ
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+gIY
+hwM
+oqA
+xFn
+fIE
+jkC
+ofs
+xbW
+arJ
+xQP
+xPt
+wPn
+wPn
+tKk
+fjR
+vcR
+vcR
+vcR
+fjR
+tKk
+wPn
+wPn
+xPt
+xQP
 pWw
-fMK
-fMK
-fMK
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-fMK
-moO
-fMK
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-fMK
-fMK
+nFm
+nFm
 pWw
-fMK
-fMK
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+glp
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
+iYN
 pWw
 pWw
-qnS
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+pWw
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -79990,61 +82581,61 @@ jxr
 tkO
 rPG
 tWR
-xDJ
-ylK
-pnD
-pnD
+xxI
+nHz
+vYd
+unW
 mUI
-jMP
-skx
-nkq
-skx
-lsT
-mUI
-pnD
-pnD
-ylK
-xDJ
-fMK
-fMK
-fMK
-fMK
-fMK
+vHZ
+vHZ
+rUi
+vHZ
+vHZ
+kCD
+sbD
+nHz
+tjz
+sbe
 pWw
+xQP
+xPt
+aIK
+wPn
+tKk
+qku
+qmF
+qmF
+qmF
+clS
+tKk
+wPn
+aIK
+xPt
+xQP
+fMK
+xCA
 nFm
-nFm
+fMK
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+kxs
+fMK
+glp
+fMK
+kxs
+kxs
+kxs
+lxq
+fMK
+fMK
 fMK
 fMK
 fMK
 pWw
-fMK
-fMK
-fMK
-pWw
-fMK
-fMK
-moO
-fMK
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-xTL
-pWw
-pWw
-fMK
-fMK
-pWw
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -80222,7 +82813,7 @@ fMK
 fMK
 nFm
 xCA
-xCA
+nFm
 jex
 ojb
 ojb
@@ -80235,64 +82826,64 @@ rgw
 cDN
 hRc
 cbC
-pWw
+iJs
 cbC
 fMK
 cbC
-pWw
+iJs
 gBe
 fMK
 cbC
-pWw
+iJs
 gBe
 tWR
 pWw
-xDJ
-ylK
+xxI
+nHz
 skx
-skx
-aAN
+uFZ
+mUI
 vHZ
 qHX
-qHX
-qHX
+qWw
+tmL
 vHZ
 fQz
-skx
-skx
-ylK
-xDJ
-xCA
-sQZ
-sQZ
-sQZ
-sQZ
-sQZ
-xCA
-xCA
-qnS
-fMK
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-fMK
-moO
-fMK
-wPn
-wPn
-wPn
-wPn
-iYN
+sbD
+qpk
+kfi
+rez
 pWw
+xQP
+xQP
+eas
+aIK
+aIK
+qku
+qmF
+rBR
+gPq
+clS
+aIK
+aIK
+tDg
+xQP
+xQP
+fMK
+xCA
+nFm
+fMK
+fMK
 fMK
 fMK
 fMK
 pWw
 fMK
+pWw
+fMK
+bpa
+fMK
+pWw
 fMK
 fMK
 fMK
@@ -80480,7 +83071,7 @@ fMK
 nFm
 xCA
 nFm
-xCA
+pWw
 rPG
 rPG
 rPG
@@ -80505,52 +83096,52 @@ ijK
 hRc
 huf
 xDJ
-ylK
-nkq
-skx
-lsT
-cdB
+nJZ
 vYd
-vYd
-vYd
-cYr
-lsT
-skx
-nkq
-ylK
+vgP
+vHZ
+vHZ
+vHZ
+qXR
+vHZ
+vHZ
+vHZ
+sbD
+nHz
+weW
 xDJ
-pWw
-pWw
-fMK
-pWw
-vkQ
-pWw
+xDJ
+xDJ
+xPt
+aIK
+wPn
+tKk
+qku
+qmF
+qmF
+qmF
+clS
+tKk
+wPn
+aIK
+xPt
+xQP
 pWw
 xCA
 nFm
-pWw
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-moO
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-uCM
-pWw
-pWw
-pWw
-pWw
-pWw
+sQZ
+sQZ
 fMK
+fMK
+kxs
+kxs
+kxs
+kxs
+fMK
+glp
+fMK
+kxs
+kxs
 fMK
 fMK
 fMK
@@ -80736,8 +83327,8 @@ fMK
 pWw
 nFm
 xCA
-pWw
-pWw
+hQS
+hQS
 rPG
 vQU
 vQU
@@ -80762,56 +83353,56 @@ kuv
 loU
 prQ
 xDJ
-ylK
+nOH
 vYd
-vYd
-vYd
-cdB
-fWM
-oUk
-vYd
-cYr
-vYd
-vYd
-vYd
-ylK
+vgP
+jJa
+bgG
+veV
+qWw
+cpo
+ovK
+sbM
+sbD
+nHz
+dCZ
 weq
-weq
-wEj
-wEj
-wEj
-weq
-weq
+rhq
+xDJ
+xPt
+wPn
+wPn
+tKk
+fjR
+cbl
+cbl
+cbl
+fjR
+tKk
+wPn
+wPn
+xPt
+xQP
 pWw
 nFm
-fMK
-fMK
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-wPn
-fMK
-moO
-fMK
-wPn
-wPn
-wPn
+nFm
+xCA
+sQZ
+pWw
+pWw
 iYN
-fMK
-fMK
-fMK
-fMK
-fMK
+iYN
+iYN
+iYN
+iYN
+glp
+iYN
+iYN
+iYN
+pWw
 pWw
 fMK
 fMK
-fMK
-fMK
-fMK
-pWw
 fMK
 fMK
 fMK
@@ -81019,58 +83610,58 @@ rNu
 jQn
 pWw
 xDJ
-ylK
-nkq
-skx
+nRu
+vYd
+aYc
 oUk
-cdB
-vYd
-vYd
-vYd
-cYr
-lsT
-skx
-nkq
-ylK
-weq
+hGn
+veV
+hbk
+cpo
+aRu
+wbV
+qIV
+lnd
+jEC
+dAH
 hZg
-aka
-aka
-aka
+xDJ
+xPt
+tyJ
 qmF
-weq
-fMK
-nFm
-fMK
-fMK
-fMK
-fMK
+qmF
+wPn
+aIK
+wRP
+aIK
+wPn
+qmF
+jvr
+tyJ
+xPt
+xQP
 fMK
 fMK
 pWw
-fMK
-pWw
-fMK
-cxH
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-qnS
-nFm
 pWw
 pWw
+fMK
+fMK
+kxs
+kxs
+kxs
+kxs
+fMK
+glp
+fMK
+kxs
+lxq
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
 fMK
 fMK
 fMK
@@ -81274,58 +83865,58 @@ fPA
 mbq
 gWy
 loU
-tWR
+prQ
 xDJ
-ylK
-skx
-skx
+nUl
+vYd
+aYc
 jJa
-vHZ
+hGn
 veV
-veV
-veV
-vHZ
-fQz
-skx
-skx
-ylK
-weq
+qWw
+cpo
+smW
+sbM
+iLH
+nHz
+dCZ
+wgf
 tiJ
+xDJ
 xPt
-pXl
-bcq
+wPn
 pZg
-weq
-pWw
-veK
-pWw
-sQZ
-sQZ
-fMK
-fMK
+aIK
+ewF
+tKk
+wRP
+tKk
 wPn
+wcf
+tyJ
 wPn
-wPn
-wPn
-fMK
-moO
-fMK
-wPn
-wPn
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-xHl
-xHl
-xHl
+xPt
+xQP
 pWw
-pWw
-pWw
-pWw
+nFm
+nFm
+xCA
+nFm
 fMK
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
+iYN
+fMK
+fMK
+mBJ
+mBJ
+mBJ
+lxq
+kxs
 fMK
 fMK
 fMK
@@ -81514,7 +84105,7 @@ rPG
 rPG
 rPG
 rPG
-ukK
+gHL
 epQ
 nJq
 cHH
@@ -81533,53 +84124,53 @@ eCk
 jQn
 pWw
 xDJ
-ylK
-pnD
-pnD
-mUI
-lsT
-skx
-nkq
+oag
+qTR
+vjt
+wOW
+alG
+nsW
+lnv
 dZz
-lsT
-mUI
-pnD
-pnD
-ylK
-weq
-gFm
-pXl
-jsL
-qhD
-eJR
-weq
+fqN
+cXl
+tNK
+gWO
+jEC
+njD
+hZg
+xDJ
+xPt
+xQP
+pZg
+iqT
 aIK
-nFm
-fMK
-pWw
-sQZ
-pWw
-pWw
-uCM
-uCM
-uCM
-uCM
-uCM
-moO
-uCM
-uCM
-uCM
-pWw
+aIK
+wPn
+aIK
+aIK
+iqT
+pZg
+xQP
+xPt
+xQP
 pWw
 fMK
+pWw
+lyh
+pWw
+pWw
+pWw
 fMK
 fMK
-xHl
-xHl
-xHl
-xHl
-xHl
 fMK
+fMK
+bin
+iYN
+fMK
+fMK
+fMK
+pWw
 fMK
 fMK
 fMK
@@ -81771,7 +84362,7 @@ xsj
 xsj
 xsj
 rPG
-rBl
+itw
 ycC
 juC
 pjv
@@ -81788,55 +84379,55 @@ gNq
 prG
 wiV
 pUz
-tWR
+prQ
 xDJ
-ylK
-skx
-skx
-pnD
-skx
-skx
-nkq
-skx
-skx
-pnD
-skx
-skx
-ylK
-weq
-tiJ
-bcq
-pXl
+oag
+vYd
+aYc
+wTW
+wTW
+xDJ
+jak
+xDJ
+gwZ
+gwZ
+pZR
+nHz
+dCZ
+iuu
+iuu
+xDJ
+xQP
 xPt
-pZg
-weq
-pWw
-veK
-pWw
-pWw
-sQZ
-fMK
-fMK
-wPn
-wPn
-wPn
-wPn
-fMK
+wRP
+xQP
+cbl
+cbl
+cbl
+cbl
+cbl
+xQP
+wRP
+xPt
+cbi
+cbi
 moO
+moO
+moO
+cbi
+cbi
 fMK
-wPn
-iYN
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-xHl
-xHl
-xHl
-fMK
-fMK
+nFm
+pWw
+pWw
+pWw
+pWw
+pWw
+mBJ
+pWw
+pWw
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -82027,9 +84618,9 @@ rPG
 oTk
 mYG
 nhr
-rAZ
+mSL
 jfU
-qgX
+rhJ
 iZl
 pet
 bxY
@@ -82047,53 +84638,53 @@ pyL
 jQn
 xDJ
 xDJ
-ylK
-vYd
+obb
+qXF
 aYc
 cem
-nkq
-nkq
+sRw
+xJD
 jak
-nkq
-nkq
-cem
-pnD
-vYd
-ylK
-weq
-kmT
-aRq
-wwA
-kdm
+uVX
+qUz
+qwA
+pZR
+tiE
+xfZ
+xDJ
+xDJ
+xDJ
+xQP
+xQP
 vic
-weq
-fMK
+xQP
+nEx
+nEx
+nEx
+nEx
+nEx
+xQP
+vic
+xQP
+cbi
+uqX
+imu
+imu
+imu
+hdl
+cbi
+pWw
 xCA
+nFm
+fMK
+fMK
+fMK
+fMK
+mBJ
+fMK
 fMK
 fMK
 pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-uCM
-fMK
-fMK
-xbM
-xbM
-xbM
-iYN
-wPn
-fMK
-fMK
-fMK
-xHl
-pWw
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -82304,53 +84895,53 @@ bVA
 dzE
 uNc
 xDJ
-ylK
-xDJ
+olV
+rTB
 vKq
+yei
+trr
+gJK
+xvB
+cTG
+gIY
+eAG
+jDs
+jmg
+txs
 xDJ
-trr
-trr
-trr
-trr
-trr
-xDJ
-vKq
-xDJ
-ylK
-weq
-weq
+upP
 wEj
-oXR
-wEj
-weq
-weq
-xCA
-xCA
-pWw
-pWw
-pWw
-pWw
-pWw
-fMK
-fMK
-fMK
-fMK
+xQP
+qLP
+tMY
+xQP
+oxB
+kGk
+kGk
+kGk
+kGk
+xQP
+tMY
+qLP
+cbi
+wlv
+bNB
 otu
-uCM
+pvg
+gjd
+cbi
+fMK
+nFm
 fMK
 fMK
 fMK
 pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+xcN
+wkf
+xcN
+xcN
 fMK
 pWw
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -82558,56 +85149,56 @@ hTY
 onB
 ljZ
 iRZ
-yjq
-yjq
-yjq
-yjq
-xDJ
-kPu
-xDJ
-lBI
-xxI
-xxI
-xxI
-xxI
+iKL
+iKL
+iKL
+oAq
 xDJ
 kPu
 xDJ
 xDJ
+xxI
+xxI
+xxI
 xDJ
-weq
-unW
-fNW
-afq
+xDJ
+eYI
+xDJ
+crT
+xDJ
+xDJ
+xDJ
+xQP
+xQP
 vHz
-weq
-nFm
+xQP
+rWk
+fxG
+dpU
+tLZ
+pwe
+xQP
+vHz
+xQP
+cbi
+lCY
+otu
+yat
+stc
+jKB
+cbi
+oPp
+xCA
 pWw
-fMK
-pWw
-fMK
-fMK
-xbM
-xbM
-xbM
-xbM
-xbM
-xbM
-xbM
-pWw
-pWw
-pWw
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-pWw
-pWw
-pWw
-fMK
+tWR
+jHj
+jHj
+jHj
+jHj
+tWR
+prQ
+prQ
+tWR
 fMK
 fMK
 fMK
@@ -82789,7 +85380,7 @@ pWw
 wzh
 yhW
 wzh
-pWw
+nFm
 nFm
 xCA
 pWw
@@ -82824,52 +85415,52 @@ pkF
 xDJ
 vBX
 qlp
-chw
+qlp
 mPP
-ydP
+eQa
 xDJ
 mBm
-xDJ
+yih
 pTo
 ecN
-rTB
+xDJ
 iwm
 xOB
 aOl
 ksK
-weq
+xQP
+dlz
+pwe
+umn
+iRT
+tru
+xQP
+pZk
+dJN
+cbi
+lLu
+pvg
+otu
+bNB
+vhI
+cbi
+fMK
 nFm
 pWw
-fMK
-sQZ
-fMK
-fMK
-xbM
-fMK
-fMK
-fMK
-fMK
-fMK
 pWw
-fMK
-fMK
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-pWw
+mBJ
 xcN
 xcN
-xcN
-vlB
 xcN
 xcN
 xcN
 xcN
 pWw
 pWw
+pWw
+fMK
+fMK
+fMK
 fMK
 fMK
 fMK
@@ -83025,7 +85616,7 @@ kxk
 jQe
 xXB
 jgA
-rnr
+bxr
 mNf
 xSl
 fMK
@@ -83056,7 +85647,7 @@ oJc
 iOd
 pEz
 jxr
-pWw
+iJs
 gcz
 gqQ
 rVg
@@ -83076,54 +85667,54 @@ huI
 oLQ
 lXx
 tIf
-xDJ
+rYz
 bNQ
-xDJ
+qUB
 ydP
-ydP
+eUS
 igt
 adj
 jTY
-xDJ
-bNQ
-xDJ
+uJa
+mRP
+wKL
 jYB
 oCY
-weq
-weq
-weq
-weq
-weq
-weq
+qQW
+spu
+gKw
+qGp
+ksK
+ern
+pwe
+dFl
+bFn
+pwe
+pwe
+ern
+hji
+aUM
+cbi
+oGO
+iws
+nPz
+sPa
+vzy
+cbi
+pWw
 xCA
-pWw
+nFm
 fMK
-pWw
-fMK
-fMK
-xbM
+mBJ
 fMK
 fMK
 fMK
-pWw
-xcN
-wZq
-xcN
-xcN
+fMK
+fMK
+fMK
+fMK
 fMK
 pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-xcN
-rYz
-vJe
-xcN
-fXj
-xcN
 fMK
 fMK
 fMK
@@ -83333,55 +85924,55 @@ yjq
 lLv
 utF
 yfi
-fAC
+iUb
 irn
 tmr
-ydP
+uao
 uao
 vUe
-ydP
-ydP
+vOo
+uao
 tmr
 eQx
 uXI
-dYz
+ski
 ych
-lZd
+xDJ
 spu
 yaW
-tWR
-pWw
-pWw
-pWw
-pWw
-uCM
-uCM
+lTV
+ksK
+ern
 xbM
+uYc
+xjM
+pGd
 xbM
-xbM
+ern
+glz
+lGc
+cbi
+cbi
+moO
+njS
+moO
+cbi
+cbi
+fMK
+nFm
+fMK
+fMK
+mBJ
+fMK
+fMK
 pWw
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-qaJ
-qHH
-qHH
-xcN
-xcN
-xcN
 pWw
+pWw
+fMK
+fMK
+fMK
+fMK
+fMK
 fMK
 fMK
 fMK
@@ -83592,52 +86183,52 @@ shz
 tIf
 xlS
 xpB
-tmr
+xDJ
 nSf
-bWe
+qlp
 cUd
-hNh
-nSf
-tmr
-qAh
+qlp
+jas
+xDJ
+xcm
 woy
-adb
-cYK
-cYK
-cig
-cYK
-cYK
-tWR
-pWw
-xaG
-fMK
-uCM
+xEt
+xDJ
+xDJ
+xQP
+mGq
+aQo
+hTh
+vJQ
+xQP
 pwe
+qvM
+pwe
+xQP
+vJQ
+glz
+oNY
+cbi
+wtV
+sqZ
+vnj
+wch
+cbi
 pWw
-fMK
-fMK
 pWw
-pWw
+mBJ
+mBJ
+mBJ
+mBJ
 pWw
 xcN
 xcN
 xcN
+sQu
 xcN
 xcN
 xcN
-pWw
-pWw
-pWw
-fMK
-fMK
-fMK
-fMK
-cLp
-qHH
-kSk
-cBf
-qHH
-vlB
+xcN
 pWw
 pWw
 fMK
@@ -83653,7 +86244,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
+xTL
 fMK
 fMK
 fMK
@@ -83849,52 +86440,52 @@ rlm
 yjq
 wNt
 sfw
-sbb
 xDJ
-ydP
-ydP
-ydP
 xDJ
-sbb
+jrc
+uao
+kVB
+xDJ
+xDJ
 vdK
 lbz
 iyT
 cYK
 pdR
-hUL
+xQP
 cac
-cYK
-cig
-cig
-tWR
+eJd
+ksK
+bCt
+xQP
+nEx
+uLc
+nEx
+xQP
+aNt
+jWe
+fJi
+sGV
+kby
+aOX
+fzU
+jku
+cbi
 fMK
-uCM
 fMK
+mBJ
+fMK
+pWw
 pWw
 fMK
 fMK
-fMK
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
+xcN
 vlB
 hyp
-luk
+xcN
 mDC
-luk
-vlB
+xcN
+fMK
 fMK
 fMK
 fMK
@@ -84047,7 +86638,7 @@ wlA
 fLl
 iGY
 jdj
-mna
+hKl
 xXB
 jjV
 jRi
@@ -84084,7 +86675,7 @@ tUd
 cGQ
 cGQ
 jxr
-pWw
+iJs
 gcz
 gqQ
 osD
@@ -84108,58 +86699,58 @@ xDJ
 pUb
 wsT
 xDJ
-trr
+tmr
 lmK
-trr
+tmr
 xDJ
 qAh
 dYz
 mVw
-mVw
+xQF
 oWk
 wbU
 aJp
-ghR
+cYb
 kRo
-iDa
-aCF
+uCM
+uCM
 pop
 uCM
+xSx
+svo
 uCM
+uCM
+qzH
+evT
+cbi
+cbi
+cbi
+cbi
+cbi
+cbi
+fMK
+fMK
+mBJ
+fMK
+xHl
+xHl
 pWw
 pWw
-pWw
-fMK
-fMK
-fMK
-pWw
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-pWw
-pWw
-fMK
-fMK
-fMK
+xDu
+aql
+aql
 xcN
 xcN
-vlB
-vlB
-cBf
-vlB
+xcN
 pWw
-pWw
-pWw
-pWw
-pWw
-pWw
-pWw
-pWw
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
 fMK
 fMK
 fMK
@@ -84363,59 +86954,59 @@ iHT
 oIl
 cWJ
 oIS
-wsT
+ikD
 tCy
-wsT
-wsT
-wsT
+iyT
+lvA
+iyT
 bih
-qAh
+jVI
 cQj
-xDJ
-xEt
-cYK
-cYK
-ghR
+tCR
+tkl
+lUc
+pdR
+xQP
 qpG
-cYK
-cig
-cYK
-xZm
-vCD
-vCD
-vCD
-xZm
-xZm
-vCD
-vCD
-vCD
-xZm
-xZm
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
+jTq
+xRF
+gvF
+mUi
+fgz
+coT
+jbo
+yio
+oNY
+oNY
+xQP
+xCA
 pWw
 pWw
+pWw
+pWw
+pWw
+pWw
+pWw
+mBJ
+xHl
+xHl
+xHl
+xHl
 fMK
-fMK
-fMK
-fMK
-fMK
-xTL
-xcN
+pbs
+aql
+oTt
+cfF
+aql
 sQu
-xcN
-pWw
-fMK
-fMK
-fMK
-fMK
 pWw
 pWw
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
 fMK
 fMK
 fMK
@@ -84626,52 +87217,52 @@ oCK
 iUb
 iap
 uQT
-lgn
+tNQ
 lIU
-xEt
-lmW
-lmW
-xDJ
-qnv
-cYK
-cYK
+kou
+tkl
+dbL
+xnd
+xnd
+oNa
+fVk
 ezf
-luk
-vCD
-xtA
+xDJ
+xDJ
+xQP
 pyx
-kdr
-ooz
 xQP
 xQP
 xQP
 xQP
-bel
-xZm
-xcN
-vlB
-vlB
-vlB
-xcN
-xcN
-xcN
-xcN
-xcN
-fMK
-fMK
-fMK
-fMK
-fMK
-fMK
-xcN
-kpX
-xcN
-fMK
-fMK
-fMK
+deL
+pWw
+pWw
 fMK
 fMK
 pWw
+fMK
+fMK
+fMK
+glp
+xHl
+xHl
+xHl
+fMK
+fMK
+sQu
+jdq
+luk
+daU
+luk
+sQu
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
+fMK
 fMK
 fMK
 fMK
@@ -84877,54 +87468,54 @@ bmt
 oIl
 cWJ
 nqF
-wsT
+wRD
 bAj
 tny
 tCR
 aHU
 xtT
-qAh
-cQj
-xEt
+aqF
+kkS
+kNh
 tkl
 nmp
-xDJ
-xTJ
-qPp
-xZm
+xnd
+cwX
+hXj
+fBM
 hXj
 cwX
-vCD
+xnd
 faQ
-aAV
+xcy
 uNm
-ooz
-wGG
-wGG
+deL
+kGH
+xYH
 pzL
-wGG
-xQP
-vCD
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-tWR
-pWw
-pWw
+pzL
+pzL
+fMK
+fMK
 pWw
 fMK
 fMK
 fMK
-fMK
+glp
+hQS
 pWw
-ijE
+hQS
+hQS
 xcN
-fMK
-fMK
+xcN
+xcN
+sQu
+sQu
+fxc
+sQu
+pWw
+pWw
+pWw
 fMK
 fMK
 fMK
@@ -85098,7 +87689,7 @@ sBE
 wQb
 pWw
 tvB
-wVK
+eXf
 psq
 tvB
 fMK
@@ -85134,52 +87725,52 @@ wkg
 gVu
 yfP
 cSw
-asm
+tCR
 wSe
 wCs
-wCs
+tsC
 jMA
-wsT
-qAh
+pvL
+hxO
 wMQ
 pvL
 rta
 oia
-xDJ
-vAm
-xZm
-xZm
-vCD
-vCD
-xZm
+xnd
+dxh
+mDY
+fBM
+mDY
+dxh
+xnd
 pUA
-pUA
-pUA
-ooz
-wGG
+xcy
+xTJ
+vmL
 wkf
-vpG
-wGG
-xQP
-xZm
-tWR
-xcN
-xcN
+wkf
+rJr
+lNc
+wKN
+iYN
+iYN
+iYN
+glp
+glp
+glp
+glp
+hQS
 pWw
-pWw
-xcN
-pWw
-pWw
-xcN
+xHl
+xHl
+xHl
+xHl
+xHl
 fMK
 fMK
 fMK
 fMK
 fMK
-fMK
-pWw
-pWw
-xcN
 fMK
 fMK
 fMK
@@ -85394,49 +87985,49 @@ bYs
 wnt
 uYo
 rVj
-ppl
+pvL
 oRb
 gNy
 cQB
 tyo
-xEt
+yaq
 wyN
-wyN
-xDJ
-xTJ
-xZm
+uGv
+xnd
+avk
+rqe
 chM
 rqe
 avk
-fsw
-vca
+xnd
+faQ
 xcy
-xcy
-ooz
-vpG
-vpG
-vpG
-vpG
-xQP
-xZm
+wGG
+deL
+dDY
+oIt
+pzL
+pzL
+pzL
+aEI
 tWR
+pWw
+fMK
+fMK
+pWw
+fMK
 xcN
-fMK
-fMK
-xHl
-xHl
-pWw
-fMK
 xHl
 xHl
 xHl
+xHl
+xHl
+xHl
+xHl
+xHl
+xHl
 fMK
 fMK
-fMK
-fMK
-pWw
-fMK
-pWw
 fMK
 fMK
 fMK
@@ -85647,36 +88238,39 @@ jEY
 lzu
 ioq
 yfP
-pcE
-pcE
+xDJ
+xEt
 qWr
 pcE
-pcE
-xDJ
-xDJ
-xEt
-iJs
 xDJ
 xEt
 xDJ
 xDJ
-xTJ
+xEt
+bgN
+xEt
+xEt
+xnd
+xnd
+xnd
+xnd
+xnd
+xnd
+xnd
+deZ
+xcy
 xZm
-kVh
-vca
-vAO
-nOH
-dfy
-dfy
-vca
-ooz
-wGG
-vpG
-vpG
-wGG
-xQP
-vCD
-tWR
+deL
+deL
+deL
+deL
+syc
+xZm
+xZm
+xZm
+xZm
+uSk
+aEI
 pWw
 xHl
 xHl
@@ -85691,9 +88285,6 @@ xHl
 xHl
 xHl
 xHl
-pWw
-fMK
-pWw
 fMK
 fMK
 fMK
@@ -85865,11 +88456,11 @@ kVz
 snv
 nwr
 qev
-tdN
+cBf
 wQb
 fMK
 xvE
-wVK
+eXf
 qGw
 xvE
 fMK
@@ -85909,32 +88500,34 @@ meK
 oyb
 krJ
 bTD
-xDJ
+eJx
 dWp
-wDw
+xDJ
 mhK
 laV
 aIN
-bLC
+urP
 xDJ
-xTJ
-xZm
+ieL
+swP
 niX
+wGG
 vca
-vca
-vca
-oag
-tKr
-vca
+xZm
+xZm
+xcy
+xZm
 uLN
 sRd
 lDl
-lDl
-sRd
-cBs
-vCD
-tWR
-xcN
+xZm
+tnq
+pdv
+tnq
+pdv
+atm
+uSk
+uSk
 xHl
 xHl
 xHl
@@ -85949,9 +88542,7 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
-fMK
+xHl
 fMK
 fMK
 fMK
@@ -86122,11 +88713,11 @@ rCz
 obr
 fvW
 uqg
-tdN
+uVC
 wQb
 fMK
 xvE
-wVK
+eXf
 qGw
 xvE
 fMK
@@ -86166,32 +88757,32 @@ bGX
 nat
 kZB
 tgf
-xDJ
+tgf
 vHB
-wsT
+xEt
 lYN
-wsT
-wsT
-iHN
+jFM
+jFM
+urP
 xDJ
-xTJ
-xZm
-cDL
+bqJ
+xVt
 ddm
-nHz
-vca
-iCC
-iCC
-vca
-vca
-vca
-wGG
+ddm
 xTJ
-wGG
-puV
+pdZ
+iCC
+xcy
+nqG
+xTJ
+eOQ
+kXm
 vCD
-tWR
-xcN
+pdv
+puV
+opb
+txa
+jjg
 xHl
 xHl
 xHl
@@ -86207,9 +88798,9 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
-fMK
+xHl
+xHl
+xHl
 fMK
 fMK
 fMK
@@ -86383,7 +88974,7 @@ wQb
 wQb
 pWw
 xvE
-wVK
+eXf
 qff
 xvE
 fMK
@@ -86418,37 +89009,37 @@ qbe
 sSC
 pmQ
 yfP
-ivl
+mHC
 nOA
 pFB
-kZB
-tgf
+tlL
+hJR
+ozA
+rhm
 xDJ
-dWp
-ala
 qEg
 szi
 fSo
 urP
 xDJ
-xTJ
+dRK
+agB
+uwx
+sTb
+uyw
 xZm
 xZm
+xcy
 xZm
+fbv
+gnl
+rUa
 xZm
-gbf
-vca
-vca
-vca
-vca
-vca
-vca
-yei
-wGG
+pdv
 txa
-xZm
-tWR
-xcN
+xmw
+puV
+oqv
 xHl
 xHl
 xHl
@@ -86465,8 +89056,8 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
+xHl
+xHl
 fMK
 fMK
 fMK
@@ -86688,23 +89279,25 @@ xDJ
 xDJ
 xDJ
 xDJ
-xTJ
-mHI
-vgP
-oAq
 xZm
-vjt
-nzY
-nzY
-nzY
-vCD
-nUl
-vca
-xTJ
-vca
+xZm
+xZm
+xZm
+xZm
+xZm
+uGp
+xcy
+xZm
+xZm
+xZm
+xZm
+xZm
+tnq
 pdv
-xZm
-tWR
+tnq
+pdv
+jjg
+uSk
 xHl
 xHl
 xHl
@@ -86722,8 +89315,6 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -86947,21 +89538,23 @@ xTJ
 xTJ
 xTJ
 xTJ
-vgP
-vBV
-xZm
+xTJ
+xTJ
+xTJ
 kxl
-dfy
+jJV
 uFR
-vST
+xZm
+oQd
+pdv
+aQs
+xZm
+xZm
 vCD
-neh
-vca
-wTW
-vca
-eXf
 vCD
-pWw
+vCD
+xZm
+xZm
 xHl
 xHl
 xHl
@@ -86980,8 +89573,6 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -87155,9 +89746,9 @@ czG
 awW
 czG
 pTD
-czG
-czG
-czG
+fsw
+fsw
+fXj
 nXq
 xsx
 uPR
@@ -87203,22 +89794,24 @@ wSj
 wSj
 wSj
 wSj
-xTJ
-vgP
-oAq
+wSj
+wSj
+wSj
+wSj
+xIz
+wGG
+mHI
 xZm
-dfy
-dfy
-dfy
-dfy
 vCD
-tmx
-vca
-xTJ
+vCD
+vCD
+iXK
 rgM
+rgM
+rgM
+rgM
+scl
 xZm
-xZm
-pWw
 xHl
 xHl
 xHl
@@ -87237,8 +89830,6 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -87414,7 +90005,7 @@ xSb
 xSb
 xSb
 xSb
-xPa
+gbf
 luR
 xsx
 dLv
@@ -87460,22 +90051,24 @@ qoO
 cBL
 fFH
 wSj
-xTJ
+eTP
+lCa
+jlx
+wSj
+xIz
+wGG
+qPp
 xZm
-xZm
-xZm
-igK
-xZm
-vCD
-vCD
-xZm
-xZm
+qYv
+ajx
 cRw
-mqv
-hST
-olV
-fMK
-fMK
+iXK
+wGG
+wGG
+cIJ
+wGG
+rgM
+xZm
 xHl
 xHl
 xHl
@@ -87494,8 +90087,6 @@ xHl
 xHl
 xHl
 xHl
-fMK
-fMK
 fMK
 fMK
 fMK
@@ -87671,7 +90262,7 @@ vLV
 jpj
 jvD
 xSb
-xPa
+gbf
 vij
 xsx
 enc
@@ -87717,21 +90308,24 @@ rua
 wHh
 rXL
 wSj
-xTJ
-xTJ
-xTJ
-xTJ
-xTJ
-xTJ
+xhp
+ptD
+egS
+wSj
+xIz
+dzG
 qIe
 xZm
-fMK
-xZm
+ygr
+eDk
 qDN
+iXK
+wGG
+wmm
+vpG
+wGG
+rgM
 xZm
-xZm
-xZm
-fMK
 xHl
 xHl
 xHl
@@ -87750,9 +90344,6 @@ xHl
 xHl
 xHl
 xHl
-xHl
-xHl
-fMK
 fMK
 fMK
 fMK
@@ -87974,37 +90565,37 @@ jcl
 kkz
 vLd
 wSj
+awX
+sbO
+iae
 wSj
-wSj
-wSj
-wSj
-wSj
-tAs
-xTJ
+xIz
 xZm
-fMK
-vCD
+xZm
+xZm
 mqv
-vCD
-fMK
-nnT
-fMK
+mqv
+mqv
+iXK
+vpG
+vpG
+vpG
+vpG
+rgM
+xZm
 xHl
 xHl
 xHl
 xHl
 xHl
-xHl
-xHl
-xHl
-xyh
-xyh
-nJZ
-xyh
+kPB
 xyh
 xyh
 uSk
-xHl
+uSk
+xyh
+xyh
+uSk
 xHl
 xHl
 xHl
@@ -88175,7 +90766,7 @@ qaU
 esn
 pxw
 tMj
-mmz
+ccc
 tdO
 xSb
 uFY
@@ -88185,7 +90776,7 @@ kGp
 nPr
 xOb
 xSb
-xPa
+gbf
 qff
 xsx
 ods
@@ -88230,38 +90821,38 @@ fVC
 uid
 gtc
 efZ
-qTR
-byd
-wSj
-dEJ
-obb
 wSj
 wSj
-xTJ
+vfT
+wSj
+wSj
+xIz
 xZm
-fMK
-xZm
+naK
+hRm
+gFS
+uuO
 fXe
+iXK
+wGG
+vpG
+vpG
+dvo
+rgM
 xZm
-fMK
-xZm
-nRu
 xHl
 xHl
 xHl
 xHl
-xHl
-xHl
-xHl
-avg
+och
+rDb
 uSk
-tyM
+dSM
 xwA
-nia
-kVZ
+pzU
+mnd
 xwA
 xyh
-xHl
 xHl
 xHl
 xHl
@@ -88442,7 +91033,7 @@ wUU
 xSb
 xSb
 xSb
-xPa
+gbf
 mmz
 cim
 mVZ
@@ -88491,34 +91082,34 @@ mCq
 guc
 cSr
 dtT
-gsm
-jgf
 wSj
-xTJ
+xIz
 xZm
-vCD
-xZm
-oVc
-xZm
-vCD
-xZm
+vLK
+vFi
+wqq
+wqq
+uuO
+pWk
+vEy
 xME
+xME
+vEy
+jKr
+xZm
 xHl
 xHl
 xHl
 xHl
-xHl
-xHl
-hQS
 mjO
-uSk
+cxk
+pgF
+gHd
 xwA
+org
 xwA
-xwA
-xwA
-xwA
-uSk
-xHl
+kOW
+xyh
 xHl
 xHl
 xHl
@@ -88663,7 +91254,7 @@ nFm
 fMK
 pWw
 fMK
-gou
+heB
 fMK
 fMK
 pWw
@@ -88699,12 +91290,12 @@ sbB
 xSb
 uZl
 xPa
-xPa
-xPa
+gsm
+hOO
 cNn
 pdg
 lSG
-xLN
+kIl
 itS
 kIl
 kIl
@@ -88745,37 +91336,37 @@ wHh
 cNN
 uNK
 azw
-wHh
+uEt
 dHM
 byC
-uFZ
-nSS
 wSj
-xTJ
-usP
-xTJ
+xIz
+xZm
+hBX
+uuO
+wqq
 rad
+uuO
+uuO
+wGG
 xTJ
-xTJ
-xTJ
-mqv
-iKL
+wGG
+swl
+xZm
+xZm
 xHl
 xHl
 xHl
 xHl
-xHl
-hQS
-wOW
 och
-fPS
-bxr
-xwA
+mjO
+uSk
+icZ
 vsN
-xwA
+wqs
 xLF
-xyh
-xHl
+xwA
+uSk
 xHl
 xHl
 xHl
@@ -89000,39 +91591,39 @@ uNK
 uOp
 bsv
 uQf
-uNK
+dUw
 qIU
 qxx
-wSj
+eAF
 ooB
-aHh
-jdt
 wSj
-xTJ
+xIz
 xZm
-xZm
-vCD
-vCD
-vCD
-xZm
-xZm
+bxl
+uqv
+wqq
+iob
+uuO
+uuO
+uuO
+wGG
 uDW
 hFm
-kAj
+xZm
 xHl
 xHl
 xHl
-hQS
-hQS
-wOW
+xHl
+xHl
+xHl
+och
 uSk
-xwA
-xwA
-xwA
-xwA
-xwA
+xyh
+xyh
 uSk
-xHl
+uSk
+uSk
+xyh
 xHl
 xHl
 xHl
@@ -89263,32 +91854,32 @@ wSj
 wSj
 wSj
 wSj
-wSj
-wSj
-xTJ
+xIz
 xZm
-fMK
-pWw
-fMK
-pWw
-fMK
 xZm
+wNj
+uuO
+uuO
+uuO
+uuO
+uuO
+uuO
 uuO
 bDW
-kAj
+vCD
 xHl
 xHl
 xHl
 xHl
-hQS
-hQS
-uSk
-xwA
-xwA
-qXF
-xwA
-xwA
-uSk
+xHl
+xHl
+xHl
+xHl
+xHl
+xHl
+xHl
+xHl
+xHl
 xHl
 xHl
 xHl
@@ -89522,16 +92113,17 @@ tsZ
 wSj
 xIz
 pWF
-xTJ
-vCD
-pWw
-bPv
+dnQ
+xZm
+wOd
 lEk
-luk
-pWw
+lEk
+lEk
 vCD
-uDW
+kQi
+uuO
 rtN
+yap
 xHl
 xHl
 xHl
@@ -89539,13 +92131,12 @@ xHl
 xHl
 xHl
 xHl
-uSk
-xyh
-oNB
-uSk
-xyh
-uSk
-xyh
+xHl
+xHl
+xHl
+xHl
+xHl
+xHl
 xHl
 xHl
 xHl
@@ -89751,7 +92342,7 @@ nlL
 lli
 yfP
 mLE
-vsQ
+lkc
 jaf
 hxR
 nhD
@@ -89778,18 +92369,18 @@ wHh
 qKL
 wSj
 vSv
-uGp
-xTJ
-vCD
-fMK
-luk
+pWF
+vJq
+xZm
+abI
+wqq
 arj
 jjK
-pWw
 vCD
-lXW
-xHl
-xHl
+hOP
+wGG
+qVZ
+vCD
 xHl
 xHl
 xHl
@@ -90034,19 +92625,19 @@ uNK
 wHh
 eWu
 wSj
-sBp
-wGG
-xTJ
+xIz
+pWF
+dnQ
 xZm
-fMK
-pWw
-fMK
-pWw
-fMK
-xZm
+wqq
+wqq
+wqq
+pAA
+vCD
+svu
 xVm
-xHl
-xHl
+xZm
+xZm
 xHl
 xHl
 xHl
@@ -90291,19 +92882,19 @@ uNK
 wHh
 ezX
 wSj
-oCe
-ccc
-xTJ
+xIz
 xZm
+xZm
+xZm
+iHe
 xZm
 vCD
 vCD
-vCD
 xZm
 xZm
-usP
+pTB
 xZm
-xHl
+bWF
 xHl
 oaT
 xHl
@@ -90548,16 +93139,16 @@ sgu
 uNK
 uNK
 wSj
-xTJ
-rlG
-xTJ
-xTJ
-xTJ
-xTJ
-xTJ
-xTJ
-rlG
-xTJ
+ioo
+jJV
+jJV
+jJV
+jJV
+jJV
+wrV
+jJV
+jJV
+jJV
 bla
 xZm
 kPh
@@ -90750,7 +93341,7 @@ xUl
 etT
 sYL
 qUb
-wks
+dEJ
 xvS
 oSb
 gWJ
@@ -90815,7 +93406,7 @@ uRi
 uRi
 uRi
 uRi
-xTJ
+oaA
 vCD
 bzR
 kPh
@@ -91072,7 +93663,7 @@ mvS
 ltJ
 xOl
 uRi
-xTJ
+oaA
 xZm
 xZm
 kPh
@@ -91295,7 +93886,7 @@ yfP
 fQR
 vsQ
 bWH
-mSL
+sKM
 kJN
 lvd
 qjb
@@ -91325,11 +93916,11 @@ lpD
 vIP
 mNp
 uRi
-cYB
+hGe
 tJY
 dzf
 uRi
-xTJ
+oaA
 uRi
 uJE
 hDY
@@ -91507,7 +94098,7 @@ hah
 kME
 kWD
 mdq
-pPa
+rpq
 jKm
 wvR
 pOJ
@@ -91553,10 +94144,10 @@ nCN
 lkc
 vzg
 sUv
-sWH
+bEZ
 pqP
 mIo
-sWH
+oNB
 ufX
 rCs
 wxt
@@ -91599,7 +94190,7 @@ xHl
 xHl
 xHl
 xHl
-xHl
+xcN
 xHl
 xHl
 xHl
@@ -91622,7 +94213,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
+xTL
 fMK
 fMK
 fMK
@@ -91843,7 +94434,7 @@ xRc
 vdt
 prm
 nOj
-vdt
+kHz
 opS
 gan
 gES
@@ -92067,7 +94658,7 @@ sKM
 vNp
 sKM
 jYi
-ufm
+tSM
 npN
 tfT
 kWF
@@ -92628,7 +95219,7 @@ tWR
 tWR
 tWR
 tWR
-fMK
+ooc
 fMK
 pWw
 fMK
@@ -93608,7 +96199,7 @@ auD
 eMk
 juQ
 wKC
-vRw
+hST
 gtG
 vjV
 uZO
@@ -95153,7 +97744,7 @@ xXW
 xXW
 xXW
 vjV
-uZO
+lKP
 vSN
 vSN
 sKD
@@ -95419,7 +98010,7 @@ vSN
 vSN
 vSN
 amb
-eEa
+pkN
 owJ
 mEj
 lVb
@@ -96446,7 +99037,7 @@ uZk
 meh
 tCz
 tJr
-vRw
+nAD
 qGE
 kwc
 wzJ
@@ -96642,7 +99233,7 @@ gKs
 iAr
 iaG
 iSq
-xBP
+adb
 xBP
 klp
 lLy
@@ -96885,7 +99476,7 @@ fMK
 fMK
 aUB
 aUB
-biR
+gou
 dnU
 bPu
 bPu
@@ -97000,7 +99591,7 @@ sZl
 odK
 hMf
 vso
-kFU
+gLb
 qfQ
 xrG
 xrG
@@ -97220,7 +99811,7 @@ tCz
 tJr
 qGE
 kwc
-xZO
+bch
 xkk
 xkk
 xkk
@@ -97671,12 +100262,12 @@ hDk
 kUs
 bIX
 biR
-xBP
+ala
 klp
 qYr
 mwF
 oNb
-kEt
+byd
 nYv
 nYv
 pOQ
@@ -97698,7 +100289,7 @@ wtn
 wyz
 xtg
 kDQ
-vRw
+hST
 qzw
 ktE
 pve
@@ -97928,7 +100519,7 @@ aUB
 biR
 aUB
 biR
-xBP
+aHh
 kmu
 kVc
 kVc
@@ -98185,7 +100776,7 @@ wuo
 ifb
 iVp
 biR
-xBP
+aRq
 kmu
 lMB
 myY
@@ -98442,7 +101033,7 @@ wuo
 kWW
 iYf
 biR
-xBP
+ala
 kmu
 lMH
 mzo
@@ -98699,7 +101290,7 @@ wuo
 iZe
 iZe
 biR
-xBP
+ala
 kmu
 lMJ
 mzK
@@ -99311,7 +101902,7 @@ fMK
 sYQ
 lnE
 fsR
-sik
+kgS
 fAh
 sik
 kgS
@@ -100001,7 +102592,7 @@ tvc
 kjQ
 tvc
 tvc
-xBP
+cLp
 uUX
 lHv
 dsP
@@ -100022,9 +102613,9 @@ cxM
 vjV
 rSH
 czP
-rSH
+iyw
 ybP
-ybP
+azZ
 nSi
 xHp
 wvY
@@ -100287,7 +102878,7 @@ iFq
 wuz
 wOy
 stW
-hDN
+ybP
 xpw
 xpw
 mqF
@@ -100757,13 +103348,13 @@ fHP
 aZo
 bPT
 qwa
-whG
+bel
 bRv
-whG
+bel
 fHP
 aZo
 bPT
-whG
+bel
 oox
 raI
 fHP
@@ -100862,7 +103453,7 @@ fTX
 dLF
 rPa
 ykW
-fMe
+aTr
 ylQ
 jPl
 oYu
@@ -101371,7 +103962,7 @@ ybh
 ykW
 pkk
 vuy
-lRP
+vbl
 rWG
 dLF
 sOx
@@ -101629,11 +104220,11 @@ ybh
 lXT
 lbd
 gqz
-ftL
+dAb
 xeN
-uOW
-gHB
-gzZ
+gbM
+teQ
+mDL
 ylQ
 ylQ
 ylQ
@@ -101887,7 +104478,7 @@ cmU
 kEM
 xsD
 rWG
-guP
+toV
 haK
 ylQ
 ylQ
@@ -102142,7 +104733,7 @@ ybh
 ykW
 pkk
 kht
-rDL
+afL
 rWG
 dLF
 sOx
@@ -102338,7 +104929,7 @@ uxY
 gnB
 wrn
 nuf
-gnX
+ngz
 jvF
 nuf
 ijy
@@ -102394,17 +104985,17 @@ dsb
 hoW
 flw
 hor
-xeO
+qib
 hor
 gmq
 cFx
 gsZ
-dQS
+rkX
 rWG
 dLF
 haK
 ylQ
-spC
+ykD
 ylQ
 ylQ
 ylQ
@@ -102656,12 +105247,12 @@ xHY
 xHY
 iZw
 xCv
-qxJ
+quQ
 rnT
 dLF
 rPa
 ykW
-fMe
+aTr
 ylQ
 oDO
 oYu
@@ -103841,15 +106432,15 @@ fHP
 nuC
 bPT
 qwR
-whG
+bel
 bRv
-whG
+bel
 fHP
 nuC
 bPT
 cfL
 oox
-whG
+bel
 fHP
 wAN
 rsl
@@ -104679,7 +107270,7 @@ wIx
 wIx
 wIx
 uFs
-xKt
+xqg
 xqg
 xqg
 xKt
@@ -105394,7 +107985,7 @@ xuy
 xuy
 oXe
 rNn
-sHD
+cxH
 tHI
 urC
 vpF
@@ -106733,7 +109324,7 @@ tIK
 dls
 wQm
 wuv
-wQm
+kKM
 aUX
 pXc
 bXi
@@ -107429,7 +110020,7 @@ eUP
 rCg
 aqe
 eHm
-heB
+hDN
 hlV
 sMv
 gUd
@@ -107938,7 +110529,7 @@ pWw
 pWw
 aqe
 vQb
-wlR
+akK
 swX
 joY
 aqe
@@ -108793,7 +111384,7 @@ dmQ
 xAS
 jWP
 fwK
-hZm
+pST
 pus
 osm
 ejg
@@ -110853,9 +113444,9 @@ qmR
 xbl
 jTi
 jTi
+nFm
 pWw
-pWw
-jcU
+oBX
 pWw
 nFm
 iEL
@@ -112867,14 +115458,14 @@ cuZ
 dBW
 tMT
 tMT
-cQC
+rAZ
 cQC
 ckw
 cQC
 cQC
 rux
 cQC
-cQC
+rHK
 bfM
 wQq
 mVH
@@ -113596,7 +116187,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
+xTL
 fMK
 fMK
 fMK
@@ -120115,7 +122706,7 @@ fMK
 fMK
 fMK
 fMK
-fMK
+xTL
 fMK
 fMK
 fMK


### PR DESCRIPTION

## About The Pull Request
Engineering part 2 electric boogaloo
## Why It's Good For The Game
Adds a suppermatter engine to Fermistation and moves the tesla to the south (tesla storage is now behind CE locked shutters)
This is good because the tesla engine had a tendency to loose midround and couldnt produce enough power on its own, making it so engineers always had to jury rig the system to run the engine.

You now have the choice to build either engine, adding the the variety of the map, while making it more accessible to more playstyles.

This update is also in anticipation of an atmospherics rework.

## Changelog
:cl:
add: El kreatura des supermatter engine
add: More maint areas near engineering
fix: some minor mapping things
/:cl:
