### PR TITLE
Updating Fermistation part 9 Atmosia rejoice

### DIFF
--- a/_maps/map_files/Fermistation/Fermistation.dmm
+++ b/_maps/map_files/Fermistation/Fermistation.dmm
@@ -19,6 +19,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"aaN" = (
+/obj/structure/sign/poster/official/we_watch{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "aaP" = (
 /obj/docking_port/stationary{
 	dwidth = 12;
@@ -39,6 +45,21 @@
 /obj/item/coin/iron,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"aaZ" = (
+/obj/structure/showcase/machinery/tv{
+	desc = "Looks like its playing an old comedy show about people working in an office on repeat... nice.";
+	name = "space TV"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"abr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/hos)
 "abt" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/HFR_corner,
@@ -57,6 +78,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/circuitboard/machine/HFR_waste_output,
+/obj/item/circuitboard/machine/HFR_corner,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "abv" = (
@@ -69,6 +92,10 @@
 	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
+"abD" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "abE" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
@@ -108,6 +135,9 @@
 /area/security/brig)
 "acK" = (
 /obj/structure/chair/sofa/corp/right,
+/obj/item/toy/plush/lizardplushie/space{
+	desc = "An adorable stuffed toy that resembles a very determined spacefaring lizardperson. Does it know its TV is placed backwards?"
+	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "acT" = (
@@ -131,10 +161,9 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "acZ" = (
@@ -182,6 +211,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/holopad,
 /turf/open/floor/engine,
 /area/science/nanite)
 "aeD" = (
@@ -220,13 +250,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aeQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aeR" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -282,13 +305,22 @@
 	dir = 8
 	},
 /area/hallway/primary/central)
+"ags" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/red,
+/area/security/brig)
 "agB" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/mmi,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "agH" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -378,7 +410,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "aje" = (
 /obj/machinery/light_switch{
 	pixel_x = -4;
@@ -508,9 +540,8 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "akB" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Port"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -590,8 +621,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/air_sensor/atmos/air_tank,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "ame" = (
 /obj/machinery/door/airlock/external{
@@ -601,6 +631,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"amh" = (
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/maint_drugs,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "anq" = (
 /obj/machinery/disposal/bin{
 	name = "emergency space exit";
@@ -696,14 +731,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aqO" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aqS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -730,8 +760,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
 "arf" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input,
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output,
+/turf/open/floor/engine/air,
 /area/engine/atmos)
 "arg" = (
 /obj/machinery/light{
@@ -743,13 +773,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/carpet,
 /area/maintenance/port/aft)
-"arq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Waste to Space"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "arw" = (
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
@@ -828,9 +851,6 @@
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "asn" = (
-/obj/item/storage/bag/trash,
-/obj/item/mop,
-/obj/item/mop,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/camera{
 	c_tag = "Prison Laundry";
@@ -838,6 +858,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "asz" = (
@@ -851,12 +872,13 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "asE" = (
-/mob/living/simple_animal/hostile/cockroach,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/storage/bag/trash,
+/obj/item/mop,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "asF" = (
@@ -919,7 +941,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/kirbyplants/random,
+/obj/effect/spawner/randomsnackvend,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "atQ" = (
@@ -1017,6 +1039,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"awo" = (
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "awt" = (
 /obj/machinery/recharge_station,
 /obj/machinery/button/door{
@@ -1142,7 +1169,18 @@
 /area/hallway/primary/central)
 "azw" = (
 /obj/structure/table/wood,
-/obj/item/toy/toy_xeno,
+/obj/item/toy/toy_xeno{
+	pixel_x = 7;
+	pixel_y = 6
+	},
+/obj/item/paper_bin/construction{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/pen/red{
+	pixel_x = -6;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet,
 /area/library)
 "azC" = (
@@ -1152,6 +1190,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"azG" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/captain)
 "azQ" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -1308,6 +1350,14 @@
 /area/security/prison/rec)
 "aCB" = (
 /obj/structure/cable,
+/obj/structure/bed/dogbed{
+	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off.";
+	name = "cat bed"
+	},
+/mob/living/simple_animal/pet/cat/kitten{
+	desc = "creatura care pandeste";
+	name = "La Creatura"
+	},
 /turf/open/floor/carpet/green,
 /area/bridge)
 "aCR" = (
@@ -1443,7 +1493,7 @@
 /area/security/prison)
 "aFq" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -1461,6 +1511,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/garden)
+"aFx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "aFD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -1547,10 +1609,6 @@
 /area/maintenance/port/aft)
 "aHU" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aIj" = (
@@ -1577,6 +1635,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "aIA" = (
@@ -1643,7 +1702,13 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "aJl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -1691,6 +1756,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
+/obj/item/circuitboard/machine/vendor,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -1710,6 +1776,8 @@
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/frame,
+/obj/item/circuitboard/machine/vendatray,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aLU" = (
@@ -1803,6 +1871,13 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/heads/cmo)
+"aMT" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aMW" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -1875,6 +1950,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "aOU" = (
@@ -1950,6 +2026,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "aQq" = (
@@ -1995,9 +2072,9 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "aRD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/mob/living/simple_animal/hostile/cockroach,
+/turf/open/floor/plasteel/white,
+/area/security/prison/mess)
 "aRH" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -2088,27 +2165,9 @@
 /turf/open/floor/plating,
 /area/security/prison/work)
 "aSS" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/medical/medbay/lobby)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/security/checkpoint/customs)
 "aSU" = (
 /obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plating,
@@ -2335,7 +2394,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aXc" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -2346,7 +2404,15 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/item/chisel,
+/obj/item/wallframe/button,
+/obj/item/wallframe/button,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/assembly/control/airlock,
+/obj/item/assembly/control/airlock,
+/obj/item/assembly/signaler,
+/obj/item/assembly/signaler,
+/obj/structure/closet,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "aXh" = (
@@ -2361,6 +2427,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aXs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "aXt" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Lab";
@@ -2416,7 +2498,7 @@
 /area/science/research)
 "aYo" = (
 /obj/machinery/gateway/centerstation,
-/turf/open/floor/plasteel,
+/turf/open/floor/circuit/off,
 /area/gateway)
 "aYB" = (
 /obj/effect/turf_decal/tile/green{
@@ -2444,6 +2526,13 @@
 	dir = 5
 	},
 /area/medical/medbay/central)
+"aZf" = (
+/obj/structure/cable,
+/obj/structure/flippedtable{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "aZg" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -2480,7 +2569,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "aZG" = (
 /obj/effect/turf_decal/loading_area{
@@ -2507,7 +2598,8 @@
 /turf/open/floor/glass/reinforced,
 /area/science/research)
 "baD" = (
-/obj/structure/barricade/wooden,
+/obj/item/book/granter/language_book/narsian,
+/obj/item/soulstone/anybody/chaplain,
 /turf/open/floor/plating/asteroid,
 /area/chapel/office)
 "bbd" = (
@@ -2568,6 +2660,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bck" = (
@@ -2627,6 +2720,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/service)
+"bej" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/turf/open/floor/plasteel/white,
+/area/engine/atmos)
 "bel" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot_white,
@@ -2696,6 +2794,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
+"bfR" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bgh" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Office";
@@ -2850,8 +2954,6 @@
 /area/security/brig)
 "bje" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bjf" = (
@@ -2935,6 +3037,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"ble" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "blo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -2951,16 +3061,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
+"blr" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "blE" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
 "blK" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = null;
+	req_one_access_txt = "5;29"
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "bmd" = (
@@ -2987,7 +3104,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bmt" = (
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/engine/break_room)
 "bmK" = (
 /obj/machinery/newscaster,
@@ -3015,9 +3136,13 @@
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
 "bmT" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bmW" = (
@@ -3044,7 +3169,7 @@
 /area/security/brig)
 "bnM" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/structure/holosign/wetsign,
+/obj/item/clothing/suit/caution,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bnS" = (
@@ -3089,6 +3214,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
+"bog" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "boi" = (
 /obj/effect/turf_decal/tile/green,
 /obj/structure/chair/stool,
@@ -3116,6 +3247,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"boF" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "boL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3145,6 +3282,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"bpk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel/white,
+/area/engine/atmos)
 "bpC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -3207,7 +3350,7 @@
 /obj/item/stack/cable_coil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mech_bay_recharge_floor,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "bqN" = (
 /obj/machinery/door/airlock/glass_large,
 /obj/effect/turf_decal/tile/neutral{
@@ -3229,8 +3372,8 @@
 /area/science/research)
 "bre" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -3291,6 +3434,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/library)
+"bsx" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "bsJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3307,8 +3456,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bsL" = (
-/obj/item/modular_computer/laptop/preset,
-/obj/structure/table,
+/obj/structure/table/reinforced,
+/obj/machinery/keycard_auth,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/office/secretary)
 "bsN" = (
@@ -3375,6 +3524,10 @@
 /obj/machinery/vending/cola/red,
 /turf/open/floor/plasteel/white,
 /area/security/prison/mess)
+"buE" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "buF" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -3399,10 +3552,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "buZ" = (
 /obj/structure/closet/crate,
@@ -3452,15 +3602,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"bwj" = (
-/obj/structure/bookcase{
-	name = "Holy Bookcase"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
 "bwr" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -3507,9 +3648,6 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bwK" = (
@@ -3519,6 +3657,12 @@
 	},
 /turf/open/floor/wood,
 /area/hydroponics/garden)
+"bwM" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "bwZ" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -3623,12 +3767,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"bxY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "byd" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/security_officer,
@@ -3651,6 +3789,7 @@
 /obj/machinery/light/small,
 /obj/structure/table/wood,
 /obj/item/toy/clockwork_watch,
+/obj/item/pen/charcoal,
 /turf/open/floor/wood,
 /area/library)
 "bzj" = (
@@ -3733,7 +3872,7 @@
 "bAC" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70;12"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -3763,8 +3902,11 @@
 	},
 /area/hallway/primary/central)
 "bBM" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -3823,6 +3965,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"bCU" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "bDc" = (
 /obj/structure/rack,
 /obj/item/clothing/head/papersack/smiley,
@@ -3841,6 +3993,23 @@
 	},
 /turf/open/floor/plasteel/stairs,
 /area/bridge)
+"bDy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics/garden)
+"bDC" = (
+/turf/closed/wall/r_wall,
+/area/engine/storage_shared)
+"bDL" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/food/grown/watermelon,
+/turf/open/floor/wood,
+/area/hydroponics/garden)
 "bDR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3910,18 +4079,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/fore)
-"bEQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bEZ" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -4077,8 +4234,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "bHU" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bHV" = (
@@ -4109,6 +4275,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bIx" = (
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "bIy" = (
 /obj/structure/closet/crate/trashcart/filled,
 /obj/item/clothing/accessory/armband/green,
@@ -4210,6 +4385,8 @@
 /area/hallway/primary/central)
 "bJQ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "bKP" = (
@@ -4256,12 +4433,35 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
+"bLG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable,
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bMh" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
+"bMj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bMy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -4301,6 +4501,12 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/engine,
 /area/medical/chemistry)
+"bMR" = (
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bNa" = (
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -4331,6 +4537,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bOC" = (
@@ -4390,6 +4599,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"bQk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/holopad,
+/turf/open/floor/plastic,
+/area/medical/surgery)
 "bQp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4411,6 +4628,22 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"bQX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bRa" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/blue{
@@ -4474,6 +4707,9 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plastic,
 /area/engine/break_room)
 "bRv" = (
@@ -4546,7 +4782,8 @@
 "bSE" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	req_access_txt = "6"
+	req_access_txt = null;
+	req_one_access_txt = "6;29"
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -4653,6 +4890,16 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
+"bUm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/plating,
+/area/vacant_room/commissary)
 "bUu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -4688,14 +4935,17 @@
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Incinerator"
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bVA" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bVE" = (
@@ -4715,11 +4965,26 @@
 /turf/open/floor/glass/reinforced,
 /area/security/brig)
 "bVU" = (
-/obj/structure/closet/toolcloset,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
+"bVV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/hydroponics)
 "bWl" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -4999,8 +5264,8 @@
 /area/crew_quarters/kitchen)
 "cbC" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
@@ -5065,24 +5330,25 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison/mess)
 "cdo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"cdq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/grimy,
+/area/security/courtroom)
 "cdr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -5100,6 +5366,10 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"cdL" = (
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "cem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -5124,10 +5394,10 @@
 /turf/open/floor/wood,
 /area/quartermaster/qm)
 "ceB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 4
 	},
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "ceQ" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -5146,9 +5416,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ceS" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "ceU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -5168,6 +5442,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cfF" = (
+/obj/structure/girder,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -5211,6 +5486,7 @@
 /area/science/research)
 "cgM" = (
 /obj/item/airlock_painter,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cgR" = (
@@ -5242,6 +5518,9 @@
 "chk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -5308,6 +5587,9 @@
 	dir = 4
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/poster/official/the_owl{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/stellar,
 /area/crew_quarters/heads/hop)
 "ciU" = (
@@ -5613,7 +5895,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "coX" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -5621,6 +5902,7 @@
 /obj/item/kirbyplants/random{
 	pixel_y = 10
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cpi" = (
@@ -5664,6 +5946,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"cps" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "cpv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -5814,6 +6105,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"csP" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"csS" = (
+/obj/item/beacon,
+/turf/open/floor/plasteel/dark,
+/area/teleporter)
 "csT" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -5884,7 +6185,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/storage)
+/area/engine/storage_shared)
 "ctA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -5913,11 +6214,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ctO" = (
+"ctL" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"ctO" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cuj" = (
@@ -5926,6 +6236,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cuo" = (
@@ -6003,12 +6314,11 @@
 /turf/open/floor/carpet,
 /area/library)
 "cwh" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cwz" = (
@@ -6046,6 +6356,7 @@
 /obj/structure/sign/poster/official/space_cops{
 	pixel_y = -32
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "cxx" = (
@@ -6329,8 +6640,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
 "cDN" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -6349,6 +6660,14 @@
 "cEx" = (
 /turf/open/floor/holofloor/dark,
 /area/science/mixing)
+"cEG" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "cEL" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -6393,6 +6712,12 @@
 /obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"cFw" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cFx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6496,12 +6821,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cHz" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "cHD" = (
@@ -6513,13 +6837,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/bridge/meeting_room)
-"cHE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cHG" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -6535,14 +6852,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cHH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -6565,8 +6882,8 @@
 /area/maintenance/port/aft)
 "cIV" = (
 /obj/structure/closet,
-/obj/item/toy/sprayoncan,
-/obj/item/restraints/legcuffs/bola,
+/obj/item/clothing/suit/nemes,
+/obj/item/clothing/head/nemes,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cIY" = (
@@ -6578,6 +6895,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cJz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cJB" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -6685,6 +7006,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "cLp" = (
@@ -6768,10 +7090,32 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"cML" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/engine/atmos)
 "cMY" = (
 /obj/effect/turf_decal/loading_area/white,
 /turf/open/floor/plating/airless,
 /area/medical/chemistry)
+"cNh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cNn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -6783,9 +7127,11 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "cNE" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Waste In"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -6891,6 +7237,22 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"cOV" = (
+/obj/structure/sign/departments/science{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "cPq" = (
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
@@ -7153,6 +7515,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"cUf" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port to Incinerator"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"cUF" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/meter/atmos,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cUH" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/bar{
@@ -7184,15 +7559,16 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cVf" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Hydroponics";
-	req_one_access_txt = "35;28"
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Hydroponics";
+	req_access_txt = null;
+	req_one_access_txt = "35;25;28"
+	},
 /turf/open/floor/plasteel/white,
 /area/hydroponics)
 "cVi" = (
@@ -7379,6 +7755,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
+"cYo" = (
+/obj/structure/cable,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cYs" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -7440,6 +7823,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
+	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dad" = (
@@ -7520,8 +7907,7 @@
 /area/medical/chemistry)
 "dbz" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -7608,15 +7994,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/stack/medical/mesh,
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/mesh{
-	pixel_x = 6
-	},
-/obj/item/stack/medical/suture{
-	pixel_x = 3
-	},
 /obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/multiver{
+	pixel_x = -6;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/glass/bottle/morphine{
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "dcT" = (
@@ -7671,10 +8059,9 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison/shower)
 "ddm" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "ddw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
@@ -7772,8 +8159,8 @@
 /area/security/prison/shower)
 "deC" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "deL" = (
@@ -7797,6 +8184,7 @@
 	},
 /obj/structure/closet,
 /obj/structure/cable,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -7881,8 +8269,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
 "dfX" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input,
-/turf/open/floor/engine/n2o,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "dge" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -8034,6 +8422,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"djG" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"djN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix Outlet Pump"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "djS" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/office)
@@ -8043,7 +8450,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "dld" = (
 /obj/structure/plaque/static_plaque/golden/captain{
 	pixel_x = 32
@@ -8117,6 +8524,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
+"dmB" = (
+/obj/item/t_scanner,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "dmM" = (
 /obj/structure/window/reinforced/spawner/west{
 	dir = 4
@@ -8143,13 +8554,13 @@
 /area/medical/surgery)
 "dmS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dmW" = (
@@ -8261,6 +8672,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"dpw" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "dpB" = (
 /obj/machinery/disposal/bin{
 	pixel_y = -3
@@ -8335,7 +8756,6 @@
 /area/quartermaster/storage)
 "drt" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8394,6 +8814,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dsc" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "dsl" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
@@ -8426,9 +8857,7 @@
 /turf/open/floor/plasteel/white/corner,
 /area/bridge)
 "dsu" = (
-/obj/structure/bookcase{
-	name = "Holy Bookcase"
-	},
+/obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "dsy" = (
@@ -8453,6 +8882,21 @@
 /obj/item/food/grown/tomato,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"dsW" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "dth" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/assistant,
@@ -8504,6 +8948,23 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"dug" = (
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Janitor Delivery";
+	req_access_txt = "26"
+	},
+/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	dir = 1;
+	freq = 1400;
+	location = "Janitor"
+	},
+/obj/structure/window/reinforced/spawner/west,
+/turf/open/floor/plating,
+/area/janitor)
 "dui" = (
 /obj/structure/sign/departments/botany{
 	pixel_y = 32
@@ -8593,9 +9054,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"dwE" = (
+/obj/structure/sign/poster/official/wtf_is_co2,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "dwF" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
+/obj/machinery/shieldgen,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "dwG" = (
@@ -8701,13 +9166,24 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/janitor)
+"dxA" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "dxI" = (
-/obj/machinery/computer/secure_data,
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"dxW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/official/work_for_a_future{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dxZ" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/stripes,
@@ -8822,8 +9298,8 @@
 /turf/open/floor/carpet,
 /area/library)
 "dzE" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -8881,16 +9357,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dBs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/research)
 "dBV" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -8918,6 +9384,16 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
+"dBY" = (
+/obj/structure/cable,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/sand,
+/obj/structure/disposalpipe/broken{
+	dir = 8;
+	layer = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dCh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -8948,7 +9424,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -9011,6 +9487,10 @@
 /obj/machinery/camera{
 	c_tag = "Chapel North"
 	},
+/turf/open/floor/plasteel/grimy,
+/area/chapel/main)
+"dEw" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
 "dEz" = (
@@ -9169,10 +9649,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/plasteel/white/side,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "dHt" = (
 /obj/machinery/door/airlock/command{
@@ -9191,8 +9672,21 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hop)
+"dHw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "dHF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dHH" = (
@@ -9264,6 +9758,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dIE" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -9412,6 +9910,9 @@
 "dLv" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/bot_white,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "dLz" = (
@@ -9449,6 +9950,21 @@
 /obj/item/encryptionkey/headset_eng,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
+"dNf" = (
+/obj/structure/cable,
+/obj/effect/mine/sound/bwoink{
+	layer = 2.15;
+	name = "faulty mine"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/sand{
+	layer = 2.2
+	},
+/obj/structure/flora/ausbushes/fullgrass{
+	icon_state = "sparsegrass_2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dNA" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "jangarage";
@@ -9587,7 +10103,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dQb" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "dQt" = (
@@ -9653,7 +10169,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "dRN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -9686,6 +10202,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison/mess)
+"dSn" = (
+/obj/structure/cable,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dSM" = (
 /obj/item/stack/sheet/metal/five,
 /turf/open/floor/plasteel/sepia,
@@ -9771,6 +10293,11 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"dVX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dWj" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
@@ -9809,6 +10336,14 @@
 	dir = 5
 	},
 /area/engine/engineering)
+"dWt" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dWH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -9921,16 +10456,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"dYg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+"dYh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/engine/atmos)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dYl" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -9957,6 +10495,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"dYD" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "dYK" = (
 /obj/item/instrument/accordion,
 /obj/item/instrument/piano_synth,
@@ -9964,6 +10512,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"dZa" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood,
+/area/crew_quarters/dorms/barracks)
 "dZg" = (
 /obj/structure/chair{
 	dir = 4
@@ -10020,6 +10575,10 @@
 /obj/machinery/camera/autoname,
 /turf/open/space/basic,
 /area/engine/engine_room)
+"eaC" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "eaW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10050,7 +10609,10 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ebt" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ebu" = (
@@ -10096,9 +10658,16 @@
 	},
 /area/quartermaster/office)
 "ecn" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/open/floor/engine/co2,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/engine/air,
 /area/engine/atmos)
+"ecu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/wood,
+/area/library)
 "ecN" = (
 /obj/machinery/shower{
 	dir = 4;
@@ -10129,6 +10698,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"edi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/library)
 "edk" = (
 /obj/structure/sign/departments/botany{
 	pixel_y = 32
@@ -10198,9 +10773,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "eeC" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
@@ -10228,6 +10805,7 @@
 	pixel_y = 32
 	},
 /obj/item/tank/internals/emergency_oxygen,
+/obj/item/storage/firstaid/o2,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "efs" = (
@@ -10275,7 +10853,7 @@
 	name = "secure storage"
 	},
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "efW" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -10289,9 +10867,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "efZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/libraryscanner,
 /turf/open/floor/wood,
 /area/library)
 "egc" = (
@@ -10319,16 +10895,10 @@
 /obj/item/food/fortunecookie,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
-"egp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"egr" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
-/area/engine/atmos)
+/area/crew_quarters/heads/chief)
 "egF" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -10394,13 +10964,6 @@
 	dir = 1
 	},
 /area/science/research)
-"eie" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "eiv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -10549,6 +11112,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"enn" = (
+/turf/closed/wall/r_wall,
+/area/library)
 "eoh" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/table/glass,
@@ -10610,6 +11176,12 @@
 	},
 /turf/open/floor/circuit,
 /area/crew_quarters/office/secretary)
+"eoV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eph" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
@@ -10660,6 +11232,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"epY" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eqF" = (
 /obj/structure/sign/warning/explosives,
 /turf/closed/wall/r_wall,
@@ -10701,6 +11279,14 @@
 "erx" = (
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
+"erE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "erK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -10739,10 +11325,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "esG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "esH" = (
@@ -10799,7 +11384,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "etr" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -10988,9 +11573,23 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
 "ezf" = (
-/obj/machinery/door/poddoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"ezj" = (
+/obj/item/circuitboard/mecha/ripley,
+/obj/item/circuitboard/mecha/ripley/main,
+/obj/item/circuitboard/mecha/ripley/peripherals,
+/obj/structure/rack,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/maintenance/port/fore)
 "ezU" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/closet/radiation,
@@ -11025,13 +11624,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ezW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Distro"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/item/toy/beach_ball,
+/turf/open/floor/plasteel/white,
+/area/security/prison/rec)
 "ezX" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet,
@@ -11088,6 +11696,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"eAY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/fore)
 "eBa" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -11163,12 +11778,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eCk" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "eCD" = (
 /obj/effect/turf_decal/tile/red{
@@ -11213,6 +11825,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
+"eDz" = (
+/obj/structure/sign/painting/library_secure{
+	pixel_y = -32
+	},
+/obj/structure/table/wood/fancy,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "secure Art Exhibition";
+	req_access_txt = "37"
+	},
+/turf/open/floor/carpet,
+/area/library)
 "eDO" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -11267,12 +11890,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "eEu" = (
-/obj/structure/closet/crate/decorations{
-	icon_state = "engi_e_crateopen"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/item/storage/belt/utility,
+/obj/structure/closet/crate{
+	icon_state = "engi_crate"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
@@ -11323,6 +11947,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eFf" = (
@@ -11419,6 +12046,11 @@
 /obj/item/tank/jetpack/improvised,
 /obj/item/extendohand,
 /obj/item/gun/ballistic/automatic/toy/pistol/riot/unrestricted,
+/obj/item/toy/waterballoon,
+/obj/item/toy/waterballoon,
+/obj/item/toy/waterballoon,
+/obj/item/toy/waterballoon,
+/obj/item/toy/waterballoon,
 /turf/open/floor/plasteel/cafeteria,
 /area/maintenance/fore)
 "eHn" = (
@@ -11470,6 +12102,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"eIa" = (
+/turf/closed/wall/r_wall,
+/area/chapel/main)
 "eIt" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -11481,6 +12116,10 @@
 	dir = 6
 	},
 /area/quartermaster/office)
+"eJa" = (
+/obj/structure/foamedmetal,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11499,6 +12138,10 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/office/secretary)
+"eJs" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/engine_room)
 "eJx" = (
 /obj/item/stack/sheet/plasteel/twenty{
 	pixel_x = -3;
@@ -11526,12 +12169,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/gateway)
-"eKa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "eKr" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room";
@@ -11619,6 +12256,10 @@
 /obj/item/clothing/under/color/teal,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
+"eMm" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "eMr" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -11712,6 +12353,10 @@
 /obj/item/reagent_containers/food/drinks/bottle/limejuice,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"eOc" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eOy" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -11741,6 +12386,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"eOC" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall,
+/area/maintenance/port/aft)
 "eOL" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11833,9 +12482,9 @@
 /area/maintenance/fore)
 "eQa" = (
 /obj/structure/cable,
-/obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/pipe_dispenser,
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "eQb" = (
@@ -11923,9 +12572,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eRA" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -12255,6 +12901,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"eVZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "eWc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -12263,6 +12916,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "eWq" = (
@@ -12317,6 +12971,11 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
+"eXD" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/space/basic,
+/area/engine/atmos)
 "eXI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -12360,6 +13019,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"eYs" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "eYw" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -12522,6 +13185,13 @@
 /obj/machinery/spaceship_navigation_beacon,
 /turf/open/floor/circuit/off,
 /area/tcommsat/server)
+"fak" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/visible{
+	dir = 4
+	},
+/obj/machinery/meter/atmos,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fav" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -12551,6 +13221,7 @@
 /area/engine/break_room)
 "faJ" = (
 /obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "faQ" = (
@@ -12607,6 +13278,10 @@
 /obj/structure/closet/l3closet,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fcI" = (
+/obj/item/banner/engineering,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fcY" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -12790,7 +13465,7 @@
 /obj/machinery/power/tesla_coil,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "fhk" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
@@ -12799,6 +13474,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"fht" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/chapel/main)
 "fhy" = (
 /obj/machinery/vending/assist,
 /obj/structure/window,
@@ -12870,6 +13549,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"fiL" = (
+/obj/item/toy/sprayoncan,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port/aft)
 "fiM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -12897,20 +13580,17 @@
 /turf/open/floor/grass,
 /area/security/prison/garden)
 "fjl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	pixel_y = -30
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "MedSci Division";
-	name = "MedSci Division"
-	},
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
-/area/science/research)
+/area/security/checkpoint/science)
 "fjx" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -13071,11 +13751,6 @@
 /turf/closed/wall/r_wall,
 /area/security/prison/garden)
 "fmX" = (
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Janitor Delivery";
-	req_access_txt = "26"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
 	dir = 1;
@@ -13255,6 +13930,10 @@
 /obj/machinery/computer/turbine_computer,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"fqD" = (
+/obj/item/toy/plush/moth/hop,
+/turf/closed/mineral/random/stationside/asteroid,
+/area/ruin/has_grav)
 "fqN" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -13262,6 +13941,10 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
+"fqO" = (
+/obj/item/toy/minimeteor,
+/turf/open/floor/plating/asteroid,
+/area/ruin/has_grav)
 "fqP" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/cable,
@@ -13310,23 +13993,14 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
 /obj/item/kirbyplants/random{
 	pixel_y = 10
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
 /area/hallway/primary/central)
-"frB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "frS" = (
 /obj/machinery/food_cart,
 /obj/structure/disposalpipe/segment{
@@ -13417,6 +14091,14 @@
 	dir = 5
 	},
 /area/security/prison/rec)
+"fug" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Auxiliary Showroom";
+	req_access_txt = "12;5"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fuh" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /obj/effect/turf_decal/trimline/green,
@@ -13453,13 +14135,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "fuN" = (
-/obj/item/storage/box/ingredients/random{
-	pixel_x = -4
-	},
-/obj/item/storage/box/ingredients/random{
-	pixel_x = 4
-	},
-/obj/structure/rack,
+/obj/machinery/grill,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "fuT" = (
@@ -13686,8 +14362,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fzk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output,
-/turf/open/floor/engine/plasma,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input,
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "fzn" = (
 /obj/machinery/computer/secure_data,
@@ -13769,6 +14445,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "fBF" = (
@@ -13788,7 +14465,8 @@
 "fBN" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Storage";
-	req_access_txt = "5"
+	req_access_txt = null;
+	req_one_access_txt = "5;29"
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -13867,6 +14545,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"fDc" = (
+/obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fDi" = (
 /obj/structure/chair{
 	dir = 8
@@ -13917,6 +14602,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"fEG" = (
+/obj/item/banner/science,
+/turf/open/floor/engine,
+/area/science/explab)
 "fFc" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -13930,13 +14619,13 @@
 	},
 /area/science/research)
 "fFp" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fFH" = (
@@ -13983,9 +14672,11 @@
 /area/crew_quarters/dorms)
 "fGv" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -14024,6 +14715,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "fHa" = (
@@ -14189,7 +14881,7 @@
 /obj/machinery/power/tesla_coil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "fKg" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
@@ -14550,7 +15242,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "fPA" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fPB" = (
@@ -14679,14 +15374,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "fSn" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -14791,6 +15486,21 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"fUq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fUP" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/decal/cleanable/dirt,
@@ -14806,8 +15516,11 @@
 /turf/open/floor/wood,
 /area/security/courtroom)
 "fVk" = (
-/obj/machinery/door/poddoor,
 /obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "Tesla Storage";
+	name = "Tesla Storage"
+	},
 /turf/open/floor/plating,
 /area/engine/storage)
 "fVs" = (
@@ -14915,18 +15628,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"fWt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/medical/medbay/lobby)
 "fWv" = (
 /obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/bot,
@@ -14942,6 +15643,7 @@
 	pixel_y = 26;
 	specialfunctions = 4
 	},
+/obj/item/clothing/gloves/color/black,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
 "fWF" = (
@@ -15011,6 +15713,20 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms/barracks)
+"fXK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "fXL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -15082,26 +15798,22 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "gak" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "gal" = (
 /obj/machinery/door/airlock/command/glass{
@@ -15180,6 +15892,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
+"gbx" = (
+/obj/machinery/air_sensor/atmos/nitrogen_tank,
+/turf/open/floor/engine/n2,
+/area/engine/atmos)
 "gbM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -15234,6 +15950,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "gcD" = (
@@ -15253,21 +15970,19 @@
 	icon_state = "lantern-on";
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "gcR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix Outlet Pump"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
+	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gcY" = (
@@ -15290,7 +16005,7 @@
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "gdl" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -15415,10 +16130,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ggk" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ggq" = (
@@ -15484,15 +16198,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"ghA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "gif" = (
 /obj/machinery/microwave,
 /obj/structure/table,
@@ -15519,6 +16224,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 10
 	},
+/obj/structure/sign/poster/official/state_laws{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "gjd" = (
@@ -15544,6 +16252,9 @@
 	dir = 1
 	},
 /obj/effect/spawner/randomcolavend,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plastic,
 /area/engine/break_room)
 "gjq" = (
@@ -15594,6 +16305,9 @@
 "gkP" = (
 /obj/structure/table/wood/poker,
 /obj/item/gun/ballistic/revolver/russian,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/bar)
 "gkV" = (
@@ -15651,6 +16365,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
+"glQ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "gmj" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -15820,8 +16538,9 @@
 	c_tag = "Atmospherics Access";
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/bot,
+/obj/item/clothing/head/beret/atmos,
+/obj/item/clothing/shoes/magboots/atmos,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "goq" = (
@@ -15846,6 +16565,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "goC" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "gpa" = (
@@ -15886,7 +16606,7 @@
 "gqj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "gqm" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
@@ -15926,6 +16646,10 @@
 /area/maintenance/port/aft)
 "gqQ" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Incinerator"
+	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "gqT" = (
@@ -16012,10 +16736,10 @@
 /area/library)
 "gtn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -16123,6 +16847,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gvn" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "gvx" = (
@@ -16247,7 +16972,9 @@
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/siding/wood,
-/obj/item/book/granter/language_book/monkey,
+/obj/item/book/granter/language_book/monkey{
+	pixel_y = 3
+	},
 /obj/item/storage/photo_album/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -16328,8 +17055,8 @@
 /area/crew_quarters/heads/cmo)
 "gzC" = (
 /obj/structure/table/wood/fancy/red,
-/obj/item/grown/shrub{
-	pixel_y = 12
+/obj/machinery/keycard_auth{
+	pixel_y = 4
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -16386,6 +17113,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "gAM" = (
@@ -16407,7 +17135,8 @@
 /area/crew_quarters/kitchen)
 "gBe" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/meter/atmos,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -16439,6 +17168,10 @@
 	pixel_y = 6
 	},
 /obj/item/cartridge/security,
+/obj/item/grown/shrub{
+	pixel_x = -11;
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "gBS" = (
@@ -16500,11 +17233,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/item/storage/belt/security/webbing,
 /obj/item/clothing/shoes/digicombat,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "gCw" = (
@@ -16650,6 +17383,9 @@
 "gEH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/clothing/suit/armor/vest/russian_coat{
+	armor = list("melee" = 25, "bullet" = 20, "laser" = 21, "energy" = 30, "bomb" = 20, "bio" = 50, "rad" = 20, "fire" = -10, "acid" = 50, "wound" = 10)
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/brig)
 "gES" = (
@@ -16668,6 +17404,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"gFE" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 8;
+	name = "Waste Release"
+	},
+/turf/closed/wall,
+/area/engine/atmos)
 "gFN" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
@@ -16710,22 +17453,38 @@
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
 "gGl" = (
-/obj/structure/rack,
 /obj/item/clothing/shoes/russian,
 /obj/item/clothing/mask/russian_balaclava,
 /obj/item/clothing/under/costume/russian_officer,
 /obj/item/clothing/suit/security/officer/russian,
-/obj/item/clothing/head/ushanka{
-	pixel_y = 7
-	},
 /obj/machinery/camera/autoname{
 	c_tag = "Uniform Room";
 	dir = 8
 	},
+/obj/item/clothing/suit/armor/vest/russian{
+	armor = list("melee" = 25, "bullet" = 10, "laser" = 20, "energy" = 20, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "wound" = 10);
+	name = "old russian vest"
+	},
+/obj/item/clothing/under/syndicate/rus_army{
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0);
+	name = "old russian tracksuit"
+	},
 /obj/item/clothing/suit/armor/vest/russian_coat{
-	armor = list("melee" = 15, "bullet" = 20, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 45);
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 30, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50, "wound" = 10);
 	desc = "Used in extremly cold fronts. This particular coat is degraded and full of holes.";
-	name = "Old russian coat"
+	name = "old russian coat"
+	},
+/obj/item/clothing/head/ushanka{
+	pixel_y = 7
+	},
+/obj/item/clothing/head/helmet/rus_ushanka{
+	armor = list("melee" = 20, "bullet" = 20, "laser" = 10, "energy" = 20, "bomb" = 20, "bio" = 50, "rad" = 20, "fire" = -10, "acid" = 50, "wound" = 5);
+	desc = "99% bear, 1% vodka. Looks a bit worn";
+	name = "old battle ushanka"
+	},
+/obj/structure/closet/crate{
+	desc = "Looks dusty";
+	name = "surplus uniform crate"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/security/brig)
@@ -16812,7 +17571,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "gHL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -16835,11 +17594,14 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"gIe" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gIn" = (
 /obj/item/tank/jetpack/carbondioxide{
 	pixel_x = -4;
@@ -16935,7 +17697,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "gJv" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gJy" = (
@@ -17124,8 +17888,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gNq" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -17240,8 +18005,8 @@
 /turf/open/floor/plating/airless,
 /area/engine/engine_room)
 "gPD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -17346,6 +18111,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gSm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "gSs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17380,7 +18155,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "gSO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17454,7 +18229,10 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/teleporter)
 "gUs" = (
 /obj/structure/chair/wood{
@@ -17566,14 +18344,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gWy" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "gWG" = (
 /obj/effect/turf_decal/sand/plating,
@@ -17634,9 +18409,14 @@
 	pixel_y = -32
 	},
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/holywater,
-/obj/item/folder{
-	pixel_y = 2
+/obj/item/reagent_containers/food/drinks/bottle/holywater{
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/hypospray/medipen/morphine{
+	desc = "A handy shortcut to reaching Jesus (or any other NT approved religious figures)";
+	list_reagents = list(/datum/reagent/water/holywater = 30);
+	name = "Heresy-B-Gone";
+	pixel_y = -4
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
@@ -17756,6 +18536,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "gYO" = (
@@ -17791,6 +18572,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"gZs" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gZv" = (
 /obj/item/wrench,
 /obj/machinery/light{
@@ -17892,6 +18677,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "haZ" = (
@@ -18018,12 +18804,14 @@
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "hdi" = (
@@ -18142,8 +18930,8 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison/rec)
 "heS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output,
-/turf/open/floor/engine/co2,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input,
+/turf/open/floor/engine/air,
 /area/engine/atmos)
 "heT" = (
 /obj/item/stack/cable_coil,
@@ -18491,6 +19279,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"hkb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hkh" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -18568,11 +19362,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "hkK" = (
-/obj/machinery/aug_manipulator,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "hkM" = (
@@ -18666,9 +19460,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -18725,6 +19518,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"hnm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Air to Mix"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hnr" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/structure/cable,
@@ -18860,6 +19660,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
+/obj/item/clothing/shoes/jackboots/digitigrade,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "hqP" = (
@@ -19068,6 +19869,9 @@
 "huI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engine_smes)
 "hvI" = (
@@ -19093,7 +19897,7 @@
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "hwt" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular{
@@ -19140,7 +19944,8 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Customs Desk";
-	req_access_txt = "19;63;2"
+	req_access_txt = null;
+	req_one_access_txt = "19;63;2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -19375,6 +20180,16 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hallway/secondary/service)
+"hBl" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/science)
 "hBo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -19436,6 +20251,11 @@
 /obj/structure/fireplace,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
+"hCa" = (
+/obj/effect/landmark/start/chaplain,
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/chapel/main)
 "hCk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19653,8 +20473,8 @@
 "hFm" = (
 /obj/structure/table/wood,
 /obj/item/stack/cable_coil,
-/obj/machinery/light,
 /obj/item/reagent_containers/food/drinks/soda_cans/grey_bull,
+/obj/machinery/light/small/broken,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "hFo" = (
@@ -19701,12 +20521,6 @@
 	},
 /turf/open/floor/bluespace,
 /area/ai_monitored/turret_protected/ai)
-"hFB" = (
-/obj/structure/closet/crate{
-	icon_state = "scicrateopen"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/warehouse)
 "hGe" = (
 /obj/structure/table,
 /obj/item/trash/candle{
@@ -19926,10 +20740,9 @@
 /area/maintenance/port/fore)
 "hLw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "hMf" = (
@@ -20147,11 +20960,9 @@
 	},
 /area/science/test_area)
 "hRc" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/brig)
 "hRk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20180,6 +20991,8 @@
 /obj/structure/sign/poster/official/walk{
 	pixel_x = 32
 	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "hRw" = (
@@ -20226,10 +21039,10 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "hSh" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 4
 	},
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "hSk" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -20356,9 +21169,9 @@
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "hTY" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Engine"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -20368,6 +21181,7 @@
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
+/obj/item/clothing/head/beret/sec/navyofficer/black,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "hUf" = (
@@ -20401,9 +21215,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "hUM" = (
@@ -20422,6 +21233,18 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"hUY" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
+"hVb" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hVj" = (
 /obj/item/beacon,
 /turf/open/floor/plating/airless,
@@ -20497,15 +21320,6 @@
 /obj/item/storage/bag/chemistry/medic,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
-"hWS" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Port"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hWX" = (
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/office/secretary)
@@ -20696,6 +21510,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/vending/wardrobe/curator_wardrobe,
+/obj/item/clothing/head/pharaoh,
 /turf/open/floor/plasteel/cult,
 /area/library)
 "iam" = (
@@ -20712,16 +21527,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"iap" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ias" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/wood,
@@ -20838,7 +21643,7 @@
 "ieL" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "ieX" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -20851,7 +21656,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/engine/engineering)
 "ifb" = (
 /mob/living/simple_animal/hostile/retaliate/frog,
 /turf/open/floor/grass,
@@ -20873,6 +21678,9 @@
 "ift" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -20967,6 +21775,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"igN" = (
+/obj/structure/table/glass,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/suture{
+	pixel_x = 3
+	},
+/turf/open/floor/glass,
+/area/medical/medbay/lobby)
 "igR" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
@@ -21005,14 +21821,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "ihk" = (
-/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
 "ihD" = (
@@ -21128,12 +21943,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "ijK" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "ijR" = (
@@ -21150,10 +21964,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ijV" = (
-/obj/structure/bookcase/random,
 /obj/structure/sign/painting/library{
 	pixel_x = 32
 	},
+/obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/library)
 "ikg" = (
@@ -21401,6 +22215,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/head/beret/eng,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "ioJ" = (
@@ -21467,6 +22284,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"iqR" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/machinery/meter/atmos,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iqT" = (
 /obj/machinery/light{
 	dir = 4
@@ -21589,18 +22413,15 @@
 /obj/item/shard,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered)
-"itw" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "itN" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"itP" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "itR" = (
 /obj/machinery/door/airlock/security/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -21904,6 +22725,9 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/trunk,
+/obj/structure/sign/poster/official/enlist{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "izE" = (
@@ -21920,13 +22744,6 @@
 	dir = 4
 	},
 /area/hydroponics)
-"izK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "iAr" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -22013,7 +22830,7 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "iCR" = (
 /obj/machinery/vending/cola/black,
 /turf/open/floor/wood,
@@ -22041,10 +22858,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "iDC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22154,13 +22972,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit,
 /area/tcommsat/computer)
-"iFF" = (
-/obj/machinery/camera/autoname,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/security/brig)
 "iFP" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -22197,10 +23008,8 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "iGL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Filter"
+	name = "Mix to Port"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -22372,12 +23181,15 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "iJK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/science)
 "iKf" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed{
@@ -22397,6 +23209,7 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "iKh" = (
+/obj/item/book/manual/nuclear,
 /obj/item/toy/figure/syndie,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered)
@@ -22485,10 +23298,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22596,6 +23409,9 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
 	},
+/obj/structure/sign/poster/contraband/borg_fancy_2{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "iNY" = (
@@ -22608,10 +23424,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "iOd" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide{
-	valve_open = 1
-	},
-/turf/open/floor/engine/n2o,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "iOf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -22627,8 +23441,8 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "iOL" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -22702,6 +23516,22 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
+	},
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8;
+	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
@@ -22808,16 +23638,15 @@
 	c_tag = "Atmospherics South East";
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "iSj" = (
@@ -22854,6 +23683,14 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"iSN" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/engine/atmos)
 "iSO" = (
 /obj/effect/turf_decal/loading_area/white,
 /turf/open/floor/plasteel/dark,
@@ -22878,6 +23715,9 @@
 "iUa" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/mineral/wood,
+/obj/item/toy/sprayoncan,
+/obj/effect/spawner/lootdrop/maintenance/five,
+/obj/item/clothing/head/beret/vintage,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "iUb" = (
@@ -22892,6 +23732,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iUC" = (
@@ -22954,13 +23795,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "iXP" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/table,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /obj/machinery/camera/autoname,
+/obj/structure/closet/crate{
+	icon_state = "o2crateopen"
+	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "iXS" = (
@@ -23011,10 +23852,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "iYv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
 	dir = 4
 	},
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "iYx" = (
 /obj/structure/beebox/unwrenched,
@@ -23060,8 +23901,8 @@
 /area/crew_quarters/heads/hos)
 "iZd" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -23085,7 +23926,7 @@
 /area/hallway/primary/central)
 "iZl" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "iZw" = (
@@ -23163,12 +24004,13 @@
 /turf/open/floor/plastic,
 /area/medical/medbay/central)
 "jaN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/closed/wall,
 /area/engine/atmos)
+"jaP" = (
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "jbm" = (
 /obj/machinery/button/door{
 	id = "xenobio1";
@@ -23216,13 +24058,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"jch" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "jcl" = (
 /obj/structure/table/wood/fancy,
 /obj/item/toy/figure/ian,
@@ -23230,10 +24065,10 @@
 /turf/open/floor/carpet,
 /area/library)
 "jcA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/library)
 "jcK" = (
@@ -23255,6 +24090,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"jcZ" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
 "jdc" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/delivery,
@@ -23301,8 +24142,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/storage/tech)
+"jeg" = (
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jer" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/landmark/xeno_spawn,
@@ -23353,7 +24204,9 @@
 /area/hallway/secondary/entry)
 "jfU" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/space/basic,
 /area/engine/atmos)
 "jfZ" = (
@@ -23458,6 +24311,14 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
+"jgY" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "jhc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -23537,6 +24398,9 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/obey{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jiP" = (
@@ -23680,15 +24544,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"jlm" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/engine/atmos)
 "jlq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23846,10 +24701,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "jnY" = (
@@ -23949,6 +24803,13 @@
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"jqa" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "jql" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
@@ -24001,10 +24862,10 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "jqC" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 4
 	},
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "jqF" = (
 /obj/structure/disposalpipe/segment,
@@ -24089,6 +24950,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "jsj" = (
@@ -24168,12 +25030,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"juc" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 8;
-	name = "plasma mixer"
+"jtZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "pump to filter"
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "juh" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -24192,7 +25056,7 @@
 "juC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "juF" = (
@@ -24324,6 +25188,7 @@
 	pixel_x = -13;
 	pixel_y = 3
 	},
+/obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "jwe" = (
@@ -24371,8 +25236,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "jxh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "incinerator mix pump"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -24545,6 +25413,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"jAG" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "jAJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -24554,11 +25429,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
-	},
 /obj/machinery/light_switch{
 	pixel_x = -26;
+	pixel_y = -26
+	},
+/obj/machinery/firealarm{
+	dir = 1;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
@@ -24605,10 +25481,6 @@
 	pixel_x = 3;
 	pixel_y = 6
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "jBv" = (
@@ -24619,11 +25491,11 @@
 	},
 /obj/machinery/light,
 /obj/structure/cable,
-/obj/machinery/keycard_auth{
-	pixel_y = -24
-	},
 /obj/item/assembly/flash/handheld{
 	pixel_x = 14
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -24640,6 +25512,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -24762,6 +25635,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/official/love_ian{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "jDy" = (
@@ -24803,7 +25679,7 @@
 /area/engine/engineering)
 "jEE" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/black,
+/obj/effect/spawner/lootdrop/maintenance/eight,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jEF" = (
@@ -24895,6 +25771,7 @@
 /area/hallway/primary/central)
 "jFt" = (
 /obj/item/dualsaber/toy,
+/obj/item/toy/nuke,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/powered)
 "jFE" = (
@@ -24914,6 +25791,7 @@
 "jFI" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/food/pizzaslice/moldy,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jFM" = (
@@ -25030,10 +25908,18 @@
 /obj/item/clothing/glasses/meson/engine/tray,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"jIo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jIz" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/landmark/start/assistant,
 /obj/item/storage/box/lights/mixed,
+/obj/item/assembly/signaler,
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "jIB" = (
@@ -25261,14 +26147,6 @@
 /obj/item/stack/cable_coil/five,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jMA" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jMC" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/newscaster{
@@ -25356,13 +26234,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jNH" = (
-/obj/effect/landmark/start/captain,
-/obj/structure/chair/comfy/teal,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "jNU" = (
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
@@ -25380,9 +26251,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "jOb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -25492,8 +26362,8 @@
 /turf/open/floor/plating,
 /area/quartermaster/miningoffice)
 "jQn" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -25588,16 +26458,25 @@
 /area/storage/tech)
 "jSa" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jSc" = (
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"jSd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jSi" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/siding/wood{
@@ -25735,6 +26614,16 @@
 /obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plastic,
 /area/medical/medbay/central)
+"jWp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos)
 "jWs" = (
 /obj/structure/closet/crate/secure/hydroponics,
 /obj/item/seeds/random,
@@ -25830,7 +26719,7 @@
 /area/tcommsat/computer)
 "jYi" = (
 /obj/structure/sign/warning/enginesafety,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/break_room)
 "jYB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -25998,6 +26887,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "kbM" = (
@@ -26028,6 +26918,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"kcQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "kcV" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
@@ -26164,6 +27072,9 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
 /area/security/brig)
 "kfi" = (
@@ -26189,6 +27100,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"kfw" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kfx" = (
 /obj/structure/displaycase/trophy,
 /obj/machinery/newscaster{
@@ -26217,6 +27135,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kfX" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "kgo" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random{
@@ -26486,7 +27415,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/secequipment,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "kln" = (
@@ -26557,9 +27486,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Unfiltered to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -26684,9 +27613,7 @@
 /area/hallway/secondary/entry)
 "kpe" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kpw" = (
@@ -26757,6 +27684,9 @@
 /obj/item/electronics/airlock,
 /obj/item/electronics/apc,
 /obj/item/electronics/apc,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
+/obj/item/wallframe/camera,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "krt" = (
@@ -26858,6 +27788,7 @@
 /area/bridge)
 "kss" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ksK" = (
@@ -26982,9 +27913,8 @@
 	},
 /obj/item/multitool,
 /obj/item/clothing/glasses/meson/engine,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
 /obj/machinery/airalarm/directional/north,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "ktL" = (
@@ -27004,13 +27934,13 @@
 	},
 /area/chapel/main)
 "ktU" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kuc" = (
@@ -27029,10 +27959,10 @@
 /area/bridge)
 "kuv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -27049,11 +27979,8 @@
 /turf/open/floor/wood,
 /area/library)
 "kuZ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Mix to Filter"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -27070,7 +27997,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
 "kvL" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/space_heater,
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
 "kvM" = (
@@ -27218,12 +28145,6 @@
 /obj/structure/sign/departments/science,
 /turf/open/floor/plating,
 /area/security/checkpoint/science)
-"kyb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "kym" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -27265,12 +28186,31 @@
 /obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/pod,
 /area/ruin/powered)
+"kzr" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kzD" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/sillycup{
+	pixel_x = -8;
+	pixel_y = 2
+	},
 /turf/open/floor/plastic,
 /area/engine/break_room)
 "kzQ" = (
@@ -27297,7 +28237,9 @@
 /area/space/nearstation)
 "kAm" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kAz" = (
@@ -27320,6 +28262,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
+"kAY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/meter/atmos,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kBp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -27449,12 +28396,11 @@
 /area/security/prison)
 "kDy" = (
 /obj/structure/grille,
+/obj/item/aicard/aitater{
+	layer = 2.8
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
-"kDM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
 "kDQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27518,6 +28464,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "kFU" = (
@@ -27566,7 +28513,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "kHs" = (
@@ -27719,10 +28668,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/library)
+"kJB" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/engine/atmos)
 "kJH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "kJL" = (
@@ -27818,11 +28778,6 @@
 /area/security/prison/rec)
 "kLF" = (
 /obj/structure/table,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld{
-	pixel_x = 3;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27836,6 +28791,15 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/item/wallframe/apc,
+/obj/item/wallframe/apc,
+/obj/item/wallframe/apc,
+/obj/item/wallframe/firealarm,
+/obj/item/wallframe/firealarm,
+/obj/item/wallframe/extinguisher_cabinet,
+/obj/item/wallframe/extinguisher_cabinet,
+/obj/item/wallframe/newscaster,
+/obj/item/wallframe/newscaster,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "kLW" = (
@@ -27877,9 +28841,13 @@
 /obj/structure/window/reinforced/spawner/north{
 	dir = 2
 	},
+/obj/structure/sign/poster/official/ion_rifle{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
 "kMk" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "kMm" = (
@@ -27981,16 +28949,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"kNB" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "kNM" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/science,
@@ -28047,6 +29005,8 @@
 /area/crew_quarters/heads/captain)
 "kOq" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "kOA" = (
@@ -28256,6 +29216,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/main)
+"kSp" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "kSt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/window{
@@ -28296,8 +29260,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "kSW" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/engine/o2,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "kTj" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -28477,6 +29441,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"kVV" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "kWf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -28735,14 +29703,14 @@
 "laZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -28998,17 +29966,11 @@
 /obj/effect/spawner/lootdrop/food_packaging,
 /turf/open/floor/plastic,
 /area/medical/medbay/central)
-"lfV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "lga" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port to Filter"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "lgc" = (
@@ -29165,7 +30127,6 @@
 /area/security/checkpoint/supply)
 "liT" = (
 /obj/machinery/power/shieldwallgen,
-/obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -29223,11 +30184,13 @@
 /area/security/prison/garden)
 "ljZ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/atmos,
+/obj/item/clothing/suit/fire/atmos,
+/obj/item/clothing/head/hardhat/atmos,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "lkc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -29305,12 +30268,13 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "llI" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/security/glass{
-	name = "MedSci Security Post";
-	req_access_txt = "63"
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
 "llO" = (
 /obj/effect/turf_decal/trimline/red/warning,
@@ -29528,10 +30492,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "loU" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/engine/atmos)
 "loY" = (
@@ -29628,6 +30590,14 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"lrq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/crate/maint,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lrt" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
@@ -29636,6 +30606,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "lrx" = (
@@ -29649,10 +30620,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"lrI" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lrV" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -29849,6 +30816,7 @@
 	name = "Captain RC";
 	pixel_y = 30
 	},
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "lvu" = (
@@ -29886,6 +30854,16 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lww" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lwC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/cargo_technician,
@@ -29909,9 +30887,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/ion_rifle{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
 "lxq" = (
@@ -29933,10 +30908,12 @@
 	},
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/item/gun/ballistic/automatic/toy,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/item/ammo_box/magazine/toy/smgm45,
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
 "lxN" = (
@@ -29949,6 +30926,7 @@
 /area/ai_monitored/security/armory)
 "lxS" = (
 /obj/structure/cable,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "lxY" = (
@@ -30098,7 +31076,7 @@
 "lBf" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
-	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70;12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -30123,6 +31101,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"lBq" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "lBI" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -30184,15 +31166,15 @@
 "lCO" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/clothing/glasses/hud/security/sunglasses/gars,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -30394,12 +31376,6 @@
 /area/hallway/secondary/entry)
 "lFp" = (
 /obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/t_scanner,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -30409,6 +31385,10 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/item/t_scanner,
+/obj/item/storage/belt/utility{
+	pixel_y = -4
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
@@ -30774,6 +31754,9 @@
 /area/security/main)
 "lLy" = (
 /obj/structure/weightmachine/weightlifter,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/white,
 /area/security/main)
 "lLz" = (
@@ -30971,6 +31954,7 @@
 /area/medical/medbay/central)
 "lOY" = (
 /obj/structure/closet/wardrobe/black,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "lPa" = (
@@ -30990,6 +31974,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "lPs" = (
@@ -31012,11 +32000,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/table,
-/obj/item/clothing/head/beret/atmos,
-/obj/item/clothing/head/beret/atmos{
-	pixel_y = 3
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "lPX" = (
@@ -31114,14 +32098,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"lRA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "O2 to Pure"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lRE" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -31170,8 +32146,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/air_sensor/atmos/oxygen_tank,
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "lSg" = (
 /obj/machinery/teleport/station,
@@ -31183,7 +32158,6 @@
 /area/quartermaster/office)
 "lSu" = (
 /obj/machinery/power/shieldwallgen,
-/obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
@@ -31397,7 +32371,7 @@
 "lVt" = (
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/engine/engineering)
 "lVU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light{
@@ -31449,9 +32423,6 @@
 /turf/open/floor/plating,
 /area/science/mixing/chamber)
 "lXb" = (
-/obj/structure/closet{
-	name = "Evidence Closet 4"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -31461,6 +32432,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/closet{
+	name = "Evidence Closet 3"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -31472,9 +32446,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "lXr" = (
-/obj/machinery/vending/boozeomat,
 /obj/item/radio/intercom{
 	pixel_y = -29
+	},
+/obj/machinery/computer/security{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -31528,9 +32504,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "lYK" = (
-/obj/structure/closet{
-	name = "Evidence Closet 3"
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -31540,6 +32513,17 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/structure/closet/secure_closet{
+	req_access_txt = "1"
+	},
+/obj/item/clothing/under/syndicate/combat{
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 40);
+	desc = "A stylish black suit with plenty of pockets. The internal armour looks worn out.";
+	has_sensor = 1;
+	name = "old combat suit";
+	random_sensor = 0;
+	sensor_mode = 3
 	},
 /obj/item/clothing/under/syndicate/camo{
 	has_sensor = 1;
@@ -31714,9 +32698,7 @@
 /area/hallway/primary/central)
 "mbq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mbv" = (
@@ -31836,8 +32818,8 @@
 /area/hallway/primary/central)
 "mdD" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/syringe,
 /obj/machinery/door/firedoor,
+/obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -31891,6 +32873,9 @@
 	c_tag = "Prison Cell Block Central";
 	dir = 1;
 	network = list("ss13","prison")
+	},
+/obj/machinery/status_display/ai{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
@@ -32230,6 +33215,11 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
+/obj/item/storage/box/wall_flash{
+	layer = 2.95;
+	pixel_x = 2;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
 "mlx" = (
@@ -32345,6 +33335,7 @@
 /obj/structure/sign/poster/contraband/syndicate_pistol{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/plasteel/sepia,
 /area/ruin/has_grav)
 "mob" = (
@@ -32477,6 +33468,8 @@
 	dir = 8
 	},
 /obj/item/analyzer,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/t_scanner,
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "mqv" = (
@@ -32524,9 +33517,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+	name = "name connector port"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -32552,10 +33544,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mtd" = (
-/obj/structure/closet/crate/maint,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
+	},
+/obj/structure/closet/crate{
+	icon_state = "scicrateopen"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
@@ -32760,7 +33754,7 @@
 /obj/machinery/power/emitter,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "mwx" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
@@ -32798,6 +33792,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "mwK" = (
@@ -33052,6 +34047,15 @@
 /area/crew_quarters/dorms)
 "mBh" = (
 /obj/structure/closet/cabinet,
+/obj/item/pen,
+/obj/item/pen/blue,
+/obj/item/pen/red,
+/obj/item/pen/fountain,
+/obj/item/folder/blue,
+/obj/item/storage/secure/briefcase{
+	layer = 2.95
+	},
+/obj/item/stack/spacecash/c50,
 /turf/open/floor/carpet/executive,
 /area/crew_quarters/office/secretary)
 "mBm" = (
@@ -33073,8 +34077,8 @@
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
 "mBO" = (
-/obj/item/pickaxe/mini,
 /obj/effect/decal/cleanable/generic,
+/obj/structure/barricade/wooden,
 /turf/open/floor/plating/asteroid,
 /area/chapel/office)
 "mCc" = (
@@ -33088,10 +34092,22 @@
 /area/space)
 "mCq" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/paper_bin/carbon{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/pen/blue{
+	pixel_x = 13;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet,
 /area/library)
 "mCV" = (
@@ -33203,8 +34219,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -33276,6 +34292,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engine_room)
 "mGE" = (
@@ -33363,10 +34380,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"mHT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "mIe" = (
 /obj/machinery/light{
 	dir = 1
@@ -33534,6 +34547,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"mKr" = (
+/obj/machinery/air_sensor/atmos/nitrous_tank,
+/turf/open/floor/engine/n2o,
+/area/engine/atmos)
 "mKR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
@@ -33895,11 +34912,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"mSL" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "mTb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -33915,6 +34927,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "mTo" = (
@@ -33932,7 +34945,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "mTX" = (
-/obj/machinery/portable_atmospherics/canister/water_vapor,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "mUb" = (
@@ -34146,28 +35159,6 @@
 	dir = 8
 	},
 /area/science/research)
-"mWe" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/status_display/evac{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/science/research)
 "mWh" = (
 /obj/structure/table,
 /obj/item/clothing/under/rank/prisoner/skirt{
@@ -34207,6 +35198,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
@@ -34361,8 +35355,8 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "mYG" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/engine/plasma,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "mYR" = (
 /obj/structure/disposalpipe/segment{
@@ -34490,6 +35484,9 @@
 "naf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -34703,13 +35700,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/clothing/suit/fire/atmos,
-/obj/item/clothing/mask/gas/atmos,
-/obj/item/clothing/head/hardhat/atmos,
-/obj/structure/rack,
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
+/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "neL" = (
@@ -34819,10 +35810,10 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "nga" = (
@@ -34877,9 +35868,8 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/bar)
 "ngD" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Unfiltered to Mix"
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -34905,21 +35895,17 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/aft)
 "nhr" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input,
-/turf/open/floor/engine/plasma,
+/obj/machinery/air_sensor/atmos/oxygen_tank,
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "nhs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/closet,
+/obj/item/restraints/handcuffs/cable,
+/obj/item/clothing/under/rank/prisoner,
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
 "nhD" = (
@@ -35024,7 +36010,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/storage)
+/area/engine/storage_shared)
 "niX" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
@@ -35032,7 +36018,7 @@
 /obj/item/hand_labeler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "njd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -35138,22 +36124,9 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "nkj" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	pixel_y = -30
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science)
@@ -35314,6 +36287,9 @@
 /area/chapel/office)
 "nmI" = (
 /obj/effect/turf_decal/stripes,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "nmR" = (
@@ -35560,6 +36536,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "nsW" = (
@@ -35673,9 +36650,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "nuj" = (
@@ -35754,12 +36732,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"nvj" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "nvk" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -35776,12 +36748,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "nwb" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
 "nwk" = (
@@ -35865,6 +36837,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/security/main)
 "nxL" = (
@@ -35904,7 +36877,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "nyo" = (
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "nyp" = (
 /obj/structure/table,
@@ -35923,10 +36896,6 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
 /area/gateway)
-"nyV" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "nyW" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -36105,20 +37074,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"nCS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "MedSci Division";
-	name = "MedSci Division"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
 "nDi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36189,8 +37144,8 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "nFj" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/engine/air,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "nFm" = (
 /obj/structure/lattice,
@@ -36335,16 +37290,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "nIE" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Tcomms & Secretary docks";
-	req_access_txt = "19"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -36353,6 +37302,10 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Tcomms & Secretary docks";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "nIO" = (
@@ -36535,11 +37488,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"nMa" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "nMv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -36631,6 +37579,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "nNz" = (
@@ -36714,6 +37665,16 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/tank/internals/oxygen/yellow,
+/obj/item/tank/internals/oxygen/yellow{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/structure/rack,
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
@@ -36766,6 +37727,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"nPi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/main)
 "nPr" = (
 /obj/machinery/requests_console{
 	department = "Detective's Office";
@@ -36895,28 +37861,28 @@
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
 "nRi" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "nRm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/vehicle/ridden/atv,
+/obj/item/key/atv,
 /turf/open/floor/plasteel,
 /area/gateway)
 "nRu" = (
@@ -37203,7 +38169,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/engine/storage)
+/area/engine/storage_shared)
 "nYg" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -37349,13 +38315,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"oam" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "oaA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -37375,11 +38334,6 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
-"oaT" = (
-/obj/item/book/granter/language_book/narsian,
-/obj/item/soulstone/anybody/chaplain,
-/turf/open/floor/plating/asteroid,
-/area/chapel/office)
 "oaV" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -37616,6 +38570,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/light,
+/obj/item/reagent_containers/hypospray/medipen/salbutamol,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "ofs" = (
@@ -37714,6 +38669,9 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
 	dir = 4
+	},
+/obj/structure/sign/poster/official/moth5{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
@@ -37819,6 +38777,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -38001,6 +38960,10 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"omk" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "omG" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -38024,19 +38987,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "onB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/structure/window/reinforced/spawner/west{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Engine"
-	},
-/turf/open/floor/plasteel,
+/obj/item/lightreplacer,
+/turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "onC" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/clothing/head/beret/ce,
 /obj/item/clothing/glasses/meson/gar,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/combat{
+	desc = "These gloves are fireproof and electrically insulated.";
+	name = "Black insulated gloves"
+	},
+/obj/item/holosign_creator/atmos,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/chief)
 "onY" = (
@@ -38064,6 +39034,11 @@
 /obj/machinery/computer/bookmanagement,
 /turf/open/floor/wood,
 /area/library)
+"ooF" = (
+/obj/effect/landmark/start/scientist,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "ooI" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -38071,6 +39046,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"ooW" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ooX" = (
 /turf/closed/wall,
 /area/medical/storage)
@@ -38207,6 +39187,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"oqX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "orc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -38231,6 +39221,7 @@
 /turf/open/floor/plasteel/sepia,
 /area/ruin/has_grav)
 "orn" = (
+/obj/machinery/holopad,
 /turf/open/floor/carpet/orange,
 /area/quartermaster/qm)
 "orq" = (
@@ -38267,6 +39258,9 @@
 "orH" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/gloves,
+/obj/item/clothing/gloves/color/black{
+	pixel_y = 3
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "orW" = (
@@ -38304,15 +39298,16 @@
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
 "osD" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "osF" = (
@@ -38635,7 +39630,6 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "oxD" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -38643,6 +39637,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "oyb" = (
@@ -38733,6 +39729,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ozn" = (
@@ -38757,6 +39756,15 @@
 /obj/item/geiger_counter,
 /obj/item/geiger_counter,
 /obj/effect/turf_decal/tile/yellow,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/clothing/under/rank/engineering/engineer/hazard,
+/obj/item/clothing/under/rank/engineering/engineer/hazard,
+/obj/item/clothing/under/rank/engineering/engineer/hazard,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/suit/radiation,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -38851,6 +39859,10 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/ai_monitored/security/armory)
+"oBM" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oBX" = (
 /obj/item/banner/medical,
 /turf/open/floor/plating/airless,
@@ -38870,8 +39882,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/air_sensor/atmos/carbon_tank,
-/turf/open/floor/engine/co2,
+/turf/open/floor/engine/air,
 /area/engine/atmos)
 "oCA" = (
 /obj/item/book/granter/crafting_recipe/pipegun_prime,
@@ -38890,9 +39901,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oCR" = (
@@ -39019,7 +40027,7 @@
 /obj/machinery/field/generator,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "oGL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -39184,8 +40192,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/air_sensor/atmos/nitrous_tank,
-/turf/open/floor/engine/n2o,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "oJg" = (
 /obj/machinery/computer/secure_data{
@@ -39214,6 +40221,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"oJH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Air to Port"
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "oJY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39228,10 +40245,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "oKb" = (
 /obj/structure/table,
@@ -39436,6 +40452,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"oNQ" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Bar backroom";
+	req_access_txt = "25"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar)
 "oNU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -39485,16 +40508,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "oPw" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "oPC" = (
@@ -39581,9 +40601,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39649,9 +40666,6 @@
 /obj/item/clothing/suit/hazardvest,
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
-"oSb" = (
-/turf/open/floor/plating,
-/area/maintenance/port)
 "oSt" = (
 /obj/structure/table,
 /obj/item/megaphone/sec,
@@ -39710,8 +40724,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/air_sensor/atmos/toxin_tank,
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "oTp" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -39779,6 +40792,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "oUz" = (
@@ -39829,6 +40844,17 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/dorms/barracks)
+"oVT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/break_room)
 "oWb" = (
 /obj/item/toy/figure/geneticist{
 	pixel_y = 13
@@ -40006,6 +41032,7 @@
 /area/security/brig)
 "oZp" = (
 /obj/item/beacon,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/quartermaster/office)
 "oZw" = (
@@ -40014,6 +41041,7 @@
 /area/engine/break_room)
 "pac" = (
 /obj/effect/decal/cleanable/oil/slippery,
+/obj/item/clothing/suit/caution,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "pae" = (
@@ -40062,7 +41090,7 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "pbm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "pbo" = (
@@ -40130,12 +41158,11 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
+/obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "pbZ" = (
@@ -40320,19 +41347,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
-"pdZ" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"pet" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	dir = 8
+"pei" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
+/turf/open/space/basic,
+/area/engine/atmos)
+"pet" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40375,6 +41405,10 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"pgd" = (
+/obj/machinery/air_sensor/atmos/toxin_tank,
+/turf/open/floor/engine/plasma,
+/area/engine/atmos)
 "pgu" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/tile/yellow,
@@ -40447,17 +41481,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"phS" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pic" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pio" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/visit)
 "pip" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/o2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Plasma Outlet Pump"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40483,24 +41528,22 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pjp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/door/airlock/security/glass{
+	name = "MedSci Security Post";
+	req_access_txt = "63"
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/medical/medbay/lobby)
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/science)
 "pjv" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "O2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40564,6 +41607,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pkN" = (
@@ -40583,9 +41629,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "pkY" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 4
-	},
 /obj/machinery/button/door{
 	id = "Secure Gate";
 	name = "Cell Shutters";
@@ -40603,6 +41646,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/computer/security{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "ple" = (
@@ -40673,11 +41719,11 @@
 	},
 /area/bridge)
 "pmP" = (
-/obj/machinery/computer/security{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
+	},
+/obj/machinery/computer/prisoner/management{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -40688,13 +41734,13 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "pmU" = (
@@ -40796,6 +41842,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"ppc" = (
+/obj/structure/table/glass,
+/obj/item/stack/medical/mesh,
+/obj/item/stack/medical/mesh{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/hypospray/medipen,
+/turf/open/floor/glass,
+/area/medical/medbay/lobby)
 "ppf" = (
 /obj/structure/chair{
 	dir = 1
@@ -40925,10 +41980,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "prg" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "prk" = (
@@ -40950,8 +42005,8 @@
 /area/chapel/office)
 "prG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Pure to Mix"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -40976,6 +42031,9 @@
 "prY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -41452,9 +42510,6 @@
 /area/engine/engine_room)
 "pyL" = (
 /obj/machinery/pipedispenser,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "pyO" = (
@@ -41484,14 +42539,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pyZ" = (
-/obj/structure/closet/crate{
-	icon_state = "o2crateopen"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/banner/cargo,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "pzu" = (
@@ -41662,7 +42715,8 @@
 	req_access_txt = "63"
 	},
 /obj/item/paper_bin{
-	layer = 2.9
+	layer = 2.9;
+	pixel_y = 5
 	},
 /obj/item/pen{
 	pixel_y = 5
@@ -41847,22 +42901,25 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "pEr" = (
-/obj/effect/turf_decal/tile/blue,
+/obj/structure/cable,
+/obj/machinery/door/airlock/glass_large{
+	id_tag = "medsciright";
+	name = "MedSci Foyer";
+	req_one_access_txt = "5"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "pEt" = (
 /obj/machinery/modular_computer/console/preset/research{
@@ -41884,7 +42941,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "pEz" = (
-/turf/open/floor/engine/n2o,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "pED" = (
 /obj/effect/landmark/start/botanist,
@@ -42136,6 +43193,11 @@
 	pixel_x = 27;
 	pixel_y = 27
 	},
+/obj/item/toy/figure/qm{
+	layer = 4;
+	pixel_x = -7;
+	pixel_y = 19
+	},
 /turf/open/floor/wood,
 /area/quartermaster/qm)
 "pKj" = (
@@ -42173,12 +43235,6 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/drinkingglasses{
 	pixel_x = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/item/storage/box/cups{
-	pixel_x = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -42308,7 +43364,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "pMF" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -42368,6 +43424,7 @@
 /obj/machinery/light/small/broken{
 	dir = 1
 	},
+/obj/item/scooter_frame,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "pNT" = (
@@ -42559,6 +43616,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "pRg" = (
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "pRl" = (
@@ -42610,6 +43668,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "pSk" = (
@@ -42650,12 +43709,12 @@
 /area/science/robotics/mechbay)
 "pTh" = (
 /obj/structure/table/reinforced,
-/obj/item/food/pizzaslice/moldy,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
 	name = "kitchen shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/food/pizzaslice/pineapple,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
 "pTo" = (
@@ -42781,11 +43840,11 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "pUz" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "pUA" = (
@@ -42797,6 +43856,9 @@
 /area/maintenance/port/aft)
 "pUB" = (
 /obj/effect/spawner/randomcolavend,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "pUM" = (
@@ -42822,6 +43884,7 @@
 	name = "Vacant Commissary Shutter"
 	},
 /obj/machinery/door/firedoor,
+/obj/item/stack/spacecash/c10,
 /turf/open/floor/plating,
 /area/vacant_room/commissary)
 "pUV" = (
@@ -42859,7 +43922,9 @@
 /area/gateway)
 "pVp" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "pVG" = (
@@ -43388,7 +44453,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "qdK" = (
 /obj/effect/turf_decal/trimline/red/warning,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -43451,6 +44516,10 @@
 	pixel_y = 5;
 	req_access_txt = "56"
 	},
+/obj/item/stock_parts/cell/emproof{
+	pixel_x = 6;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "qef" = (
@@ -43460,29 +44529,30 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
 "qel" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/glass_large{
+	id_tag = "medscileft";
+	name = "MedSci Foyer";
+	req_one_access_txt = "47"
+	},
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/item/kirbyplants/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "qev" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -43610,9 +44680,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
 	name = "Atmospherics Blast Door"
@@ -43621,6 +44688,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "qgC" = (
@@ -43643,6 +44713,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/heads/cmo)
 "qhs" = (
@@ -43774,9 +44845,9 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
-/obj/item/paper/crumpled{
-	pixel_x = 10;
-	pixel_y = -2
+/obj/item/clothing/suit/ianshirt{
+	pixel_x = -4;
+	pixel_y = -6
 	},
 /turf/open/floor/carpet/stellar,
 /area/crew_quarters/heads/hop)
@@ -43870,20 +44941,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/quartermaster/office)
-"qkN" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+"qkZ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"qkZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "qld" = (
@@ -44054,6 +45122,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/port)
+"qoD" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/medical/medbay/lobby)
 "qoH" = (
 /obj/structure/table,
 /obj/item/inspector{
@@ -44154,6 +45232,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"qpq" = (
+/obj/effect/landmark/start/paramedic,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "qpv" = (
 /obj/item/bedsheet/rd,
 /obj/structure/bed,
@@ -44224,6 +45308,7 @@
 /obj/structure/sign/warning/pods{
 	pixel_y = -32
 	},
+/obj/item/folder/red,
 /turf/open/floor/plasteel,
 /area/security/main)
 "qqH" = (
@@ -44456,12 +45541,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"qvd" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Air to Distro"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "qvf" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -44538,10 +45617,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/bridge/meeting_room)
 "qwl" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "qwo" = (
@@ -44602,6 +45678,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/bridge)
 "qxE" = (
@@ -44640,16 +45717,15 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"qyo" = (
-/obj/structure/table/wood,
-/obj/item/stamp/law,
-/turf/open/floor/wood,
-/area/security/courtroom)
 "qyH" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/southright{
+	dir = 1;
+	req_access_txt = "63"
+	},
 /obj/structure/window/reinforced/spawner/north{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "qyL" = (
@@ -44840,6 +45916,8 @@
 /area/maintenance/starboard/aft)
 "qBC" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/item/stack/sheet/metal/fifty,
+/obj/structure/rack,
 /turf/open/floor/circuit,
 /area/science/robotics/lab)
 "qBN" = (
@@ -45041,7 +46119,7 @@
 /turf/open/floor/carpet,
 /area/library)
 "qEx" = (
-/obj/machinery/vending/wardrobe/robo_wardrobe,
+/obj/machinery/aug_manipulator,
 /turf/open/floor/circuit,
 /area/science/robotics/lab)
 "qEH" = (
@@ -45098,6 +46176,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "qFf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
@@ -45306,12 +46388,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qHX" = (
-/obj/machinery/airalarm/engine{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/airalarm/engine{
+	pixel_y = 23
+	},
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_x = 26;
+	req_access_txt = "10;24"
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -45320,6 +46407,9 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/wrench,
 /obj/item/clothing/gloves/color/black,
+/obj/item/clothing/under/smc/mechanic{
+	layer = 2.7
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qIl" = (
@@ -45359,12 +46449,15 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "qIx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/science)
 "qIL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -45391,6 +46484,10 @@
 	dir = 2
 	},
 /obj/item/electronics/airlock,
+/obj/item/assembly/signaler{
+	pixel_x = -13;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "qIU" = (
@@ -45509,12 +46606,11 @@
 /obj/structure/sign/painting/library_secure{
 	pixel_y = -32
 	},
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Secure Art Exhibition";
+/obj/structure/table/wood/fancy,
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "secure Art Exhibition";
 	req_access_txt = "37"
 	},
-/obj/structure/table/wood/fancy,
 /turf/open/floor/carpet,
 /area/library)
 "qKR" = (
@@ -45635,18 +46731,18 @@
 /turf/open/floor/plasteel,
 /area/storage/tools)
 "qMf" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "qMC" = (
@@ -45762,21 +46858,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"qNU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "MedSci Division";
-	name = "MedSci Division"
-	},
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
 "qOo" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -45838,15 +46919,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qQb" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "qQd" = (
@@ -45975,6 +47054,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -46130,6 +47210,13 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"qXA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "qXC" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -46192,6 +47279,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"qYQ" = (
+/obj/machinery/air_sensor/atmos/air_tank,
+/turf/open/floor/engine/air,
+/area/engine/atmos)
 "qYT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46310,10 +47401,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "rbb" = (
-/obj/machinery/vending/cigarette,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/restaurant_portal/bar,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rbr" = (
@@ -46610,6 +47701,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
@@ -46660,10 +47752,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "rhL" = (
@@ -46706,6 +47797,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"rif" = (
+/obj/machinery/air_sensor/atmos/mix_tank,
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "rii" = (
 /obj/machinery/light,
 /turf/open/floor/grass,
@@ -46916,6 +48011,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "rmk" = (
@@ -47021,10 +48117,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"rnu" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/wood,
-/area/library)
 "rnT" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/button/door{
@@ -47045,6 +48137,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
+"rnV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "roa" = (
 /turf/open/space/basic,
 /area/security/main)
@@ -47072,14 +48175,13 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "roI" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/airlock/glass_large{
-	id_tag = "medsciright";
-	name = "MedSci Foyer";
-	req_one_access_txt = "5"
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "roL" = (
@@ -47169,7 +48271,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/secequipment,
+/obj/effect/spawner/randomsnackvend,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "rpS" = (
@@ -47342,6 +48444,7 @@
 /area/bridge)
 "rsT" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "rsX" = (
@@ -47485,7 +48588,18 @@
 /area/tcommsat/server)
 "ruN" = (
 /obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plasteel/white,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "ruX" = (
 /obj/effect/turf_decal/tile/green{
@@ -47495,12 +48609,13 @@
 /area/crew_quarters/dorms)
 "rvf" = (
 /obj/structure/rack,
-/obj/item/beacon,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark,
+/obj/item/storage/toolbox/emergency,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/teleporter)
 "rvt" = (
 /obj/structure/table,
@@ -47658,7 +48773,11 @@
 "rzd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "rzi" = (
@@ -47747,11 +48866,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"rAE" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "rAH" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -47830,9 +48944,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "rBN" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 8
 	},
+/obj/machinery/meter/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "rBR" = (
@@ -47907,7 +49022,6 @@
 /area/ruin/has_grav)
 "rDC" = (
 /obj/structure/table/wood,
-/obj/item/clothing/head/wig/random,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms/barracks)
 "rEj" = (
@@ -48001,7 +49115,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -48028,7 +49141,7 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/engine/storage)
+/area/engine/storage_shared)
 "rFz" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
@@ -48415,13 +49528,6 @@
 /obj/machinery/xenoarch/digger,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"rME" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/engine/atmos)
 "rMP" = (
 /obj/structure/bed,
 /obj/item/virgin_mary{
@@ -48472,15 +49578,27 @@
 /area/crew_quarters/dorms)
 "rNu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2O Outlet Pump"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
+"rNx" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/security/checkpoint/science)
 "rNE" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -48537,6 +49655,7 @@
 	pixel_y = -26
 	},
 /obj/item/storage/box/lights/mixed,
+/obj/item/megaphone,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "rOR" = (
@@ -48669,8 +49788,10 @@
 /turf/open/floor/wood,
 /area/hydroponics)
 "rRa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/window/reinforced/spawner/west,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/clothing/glasses/meson/engine/tray,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "rRp" = (
@@ -48868,6 +49989,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "rUt" = (
@@ -48899,14 +50023,14 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "rVg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -48921,9 +50045,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -48977,7 +50098,8 @@
 /obj/machinery/door/window/brigdoor/southright{
 	dir = 8;
 	name = "Customs Desk";
-	req_access_txt = "19"
+	req_access_txt = null;
+	req_one_access_txt = "19;63;2"
 	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -49089,6 +50211,12 @@
 "rYz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -49232,6 +50360,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -49416,6 +50547,13 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
+"scW" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
 "scZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -49437,14 +50575,15 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "sdu" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/costume,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "seh" = (
@@ -49687,7 +50826,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/machinery/restaurant_portal/bar,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "shf" = (
@@ -49832,6 +50971,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "skJ" = (
@@ -49864,11 +51004,7 @@
 	},
 /area/hallway/primary/central)
 "slA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Air to Pure"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "slT" = (
@@ -49910,10 +51046,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"sml" = (
-/obj/item/toy/plush/moth/hop,
-/turf/closed/mineral/random/stationside/asteroid,
-/area/ruin/has_grav)
 "smn" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plasteel/white/side{
@@ -49951,9 +51083,6 @@
 	},
 /obj/item/clothing/head/beret/cargo{
 	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/west{
-	dir = 4
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -50063,7 +51192,17 @@
 	name = "Atmospherics Blast Door"
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Mix to Filter"
+	},
 /turf/open/floor/plasteel/dark,
+/area/engine/atmos)
+"sot" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "soJ" = (
 /obj/machinery/chem_heater,
@@ -50076,6 +51215,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"soW" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "spi" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/airalarm/directional/east,
@@ -50214,6 +51359,21 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main)
+"ssA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "stc" = (
 /obj/machinery/gravity_generator/main/station,
 /obj/effect/turf_decal/bot_white,
@@ -50282,7 +51442,7 @@
 	normalspeed = 0;
 	req_access_txt = "55"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
 "sux" = (
 /obj/structure/chair{
@@ -50326,6 +51486,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"suW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "svg" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -50392,7 +51560,7 @@
 	dir = 8
 	},
 /obj/machinery/flasher{
-	id = "Cell 1";
+	id = "Cell 3";
 	pixel_x = -28
 	},
 /obj/machinery/camera{
@@ -50491,26 +51659,31 @@
 /turf/open/floor/carpet,
 /area/bridge/showroom/corporate)
 "swM" = (
-/obj/structure/table,
 /obj/effect/turf_decal/stripes,
-/obj/machinery/cell_charger,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "engineering security door"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Engineering";
-	req_access_txt = "10"
-	},
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/break_room)
 "swP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
+"swR" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering";
+	req_one_access_txt = "10;24;19"
+	},
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "swT" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -50657,6 +51830,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "szp" = (
@@ -50695,13 +51871,14 @@
 /area/engine/engineering)
 "sAE" = (
 /obj/structure/table/reinforced,
-/obj/item/mmi,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 1
 	},
+/obj/item/aicard,
+/obj/item/mmi,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "sAL" = (
@@ -50981,11 +52158,6 @@
 	id = "robotics";
 	name = "robotics lab shutters"
 	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty{
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "sEn" = (
@@ -51030,8 +52202,11 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "sEW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "O2 to Pure"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -51168,10 +52343,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 5
-	},
-/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sHy" = (
@@ -51266,6 +52437,13 @@
 "sIP" = (
 /turf/open/floor/plasteel/white/side,
 /area/science/research)
+"sJm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white/side,
+/area/medical/medbay/central)
 "sJv" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -51760,6 +52938,9 @@
 /area/space/nearstation)
 "sRd" = (
 /obj/item/clothing/head/welding,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sRq" = (
@@ -51894,7 +53075,9 @@
 /area/crew_quarters/dorms)
 "sSE" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "sSP" = (
@@ -51910,8 +53093,11 @@
 "sTb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/robot_suit,
+/obj/machinery/light/broken{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "sTH" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -51934,14 +53120,16 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "sUa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "CO2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -52054,8 +53242,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -52217,10 +53405,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
-"tbh" = (
-/obj/structure/bookcase/random/fiction,
-/turf/open/floor/carpet,
-/area/library)
 "tbz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -52340,6 +53524,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "tdl" = (
+/obj/structure/chair/comfy/teal,
+/obj/effect/landmark/start/captain,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "tds" = (
@@ -52589,6 +53775,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -31
 	},
+/obj/item/storage/box/cups,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "tiA" = (
@@ -52625,6 +53812,10 @@
 /obj/structure/table/glass,
 /obj/item/newspaper,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/item/storage/pill_bottle/epinephrine{
+	pixel_x = 14;
+	pixel_y = 4
+	},
 /turf/open/floor/plastic,
 /area/medical/medbay/central)
 "tji" = (
@@ -52656,7 +53847,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tjz" = (
@@ -52679,7 +53869,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tjR" = (
@@ -52760,6 +53949,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "tkU" = (
@@ -52800,9 +53992,6 @@
 /area/medical/virology)
 "tlL" = (
 /obj/structure/closet/crate/solarpanel_medium,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -52811,6 +54000,10 @@
 	dir = 8
 	},
 /area/engine/engineering)
+"tlR" = (
+/obj/machinery/air_sensor/atmos/carbon_tank,
+/turf/open/floor/engine/co2,
+/area/engine/atmos)
 "tmc" = (
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101{
 	desc = "Looks like this spider went to culinary school.";
@@ -52897,6 +54090,7 @@
 /area/engine/engineering)
 "tmL" = (
 /obj/structure/rack,
+/obj/item/geiger_counter,
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "tmS" = (
@@ -52963,10 +54157,6 @@
 /area/hallway/secondary/entry)
 "tnm" = (
 /obj/machinery/computer/security/qm,
-/obj/item/toy/figure/qm{
-	pixel_x = -7;
-	pixel_y = 19
-	},
 /obj/item/storage/secure/safe{
 	pixel_y = 30
 	},
@@ -52990,9 +54180,6 @@
 	},
 /obj/item/pipe_dispenser,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tnA" = (
@@ -53049,7 +54236,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "tnU" = (
 /obj/structure/grille,
@@ -53075,10 +54266,12 @@
 /turf/open/floor/wood,
 /area/library)
 "toq" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "toD" = (
@@ -53146,12 +54339,19 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "tpL" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "MedSci Division";
 	name = "MedSci Division"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "tpS" = (
 /obj/machinery/computer/security,
@@ -53198,7 +54398,7 @@
 	c_tag = "Engineering Secure Storage"
 	},
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "tqx" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/red,
@@ -53229,12 +54429,6 @@
 "tqY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"trc" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -53288,14 +54482,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"tsC" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tsF" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/candle_box,
+/obj/item/storage/fancy/candle_box{
+	pixel_x = -15
+	},
+/obj/item/clothing/under/costume/mummy,
+/obj/item/clothing/mask/mummy,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "tsH" = (
@@ -53339,7 +54532,9 @@
 /turf/open/floor/plasteel,
 /area/gateway)
 "tsN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Distro"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tsQ" = (
@@ -53473,6 +54668,9 @@
 /area/security/brig)
 "twn" = (
 /obj/effect/spawner/randomsnackvend,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "twH" = (
@@ -53515,7 +54713,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "txa" = (
 /turf/open/floor/plating/airless,
@@ -53525,11 +54733,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/geiger_counter,
 /obj/item/clothing/glasses/meson,
+/obj/structure/table,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "txw" = (
@@ -53562,6 +54770,7 @@
 "txT" = (
 /obj/structure/table,
 /obj/item/storage/box/gum,
+/obj/item/storage/firstaid/brute,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/dorms)
 "txW" = (
@@ -53680,6 +54889,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/service)
 "tAs" = (
@@ -53700,12 +54910,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"tBm" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tCn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53767,6 +54971,7 @@
 	pixel_y = -5;
 	req_access_txt = "10;24"
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tCz" = (
@@ -53865,6 +55070,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tDZ" = (
@@ -53884,7 +55090,7 @@
 "tEv" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
-	req_access_txt = "63"
+	req_access_txt = "1"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -53939,6 +55145,17 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"tGj" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plastic,
+/area/engine/break_room)
 "tGq" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -53974,6 +55191,7 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tGK" = (
@@ -53993,6 +55211,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/bot,
+/obj/item/clothing/head/beret/atmos,
+/obj/item/clothing/shoes/magboots/atmos,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "tHg" = (
@@ -54098,10 +55318,6 @@
 /area/crew_quarters/toilet)
 "tIF" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tIK" = (
@@ -54129,13 +55345,14 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "tJw" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/item/lightreplacer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "tJC" = (
@@ -54205,6 +55422,11 @@
 /obj/item/clothing/shoes/wheelys/rollerskates,
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet)
+"tKu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "tKF" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -54256,6 +55478,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -54304,6 +55527,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "tLV" = (
@@ -54319,6 +55545,7 @@
 /area/engine/engine_room)
 "tMj" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "tMo" = (
@@ -54455,8 +55682,12 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "tOK" = (
@@ -54657,10 +55888,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"tRj" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "tRm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -54751,6 +55978,9 @@
 /area/chapel/office)
 "tSL" = (
 /obj/structure/chair,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "tSM" = (
@@ -54863,8 +56093,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tUX" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/engine/n2,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "tUY" = (
 /obj/machinery/igniter/incinerator_atmos,
@@ -54939,6 +56169,9 @@
 /obj/machinery/camera{
 	c_tag = "Law Office"
 	},
+/obj/machinery/computer/security/telescreen/prison{
+	pixel_y = 28
+	},
 /turf/open/floor/carpet,
 /area/security/courtroom)
 "tXi" = (
@@ -54992,11 +56225,15 @@
 /area/medical/psychology)
 "tXS" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/item/toy/figure/lawyer{
+	pixel_y = 11
+	},
 /turf/open/floor/carpet,
 /area/security/courtroom)
 "tXV" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "tYk" = (
@@ -55013,6 +56250,9 @@
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/hand_labeler,
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "tYu" = (
@@ -55067,8 +56307,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -55099,7 +56339,7 @@
 /area/hallway/secondary/entry)
 "tZS" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12;42"
+	req_access_txt = "42"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -55188,7 +56428,7 @@
 /turf/open/floor/plating,
 /area/vacant_room/office)
 "ucR" = (
-/obj/item/toy/beach_ball,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/security/prison/rec)
 "ucU" = (
@@ -55260,6 +56500,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "uex" = (
@@ -55302,7 +56543,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -55331,7 +56572,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/engine/storage)
+/area/engine/storage_shared)
 "ugk" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -55380,24 +56621,28 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
 "uhc" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "22;25;26;28;35;37;38;46;70;12"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "22;25;26;28;35;37;38;46;70"
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "uhd" = (
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/machinery/door/airlock/glass_large{
-	id_tag = "medscileft";
-	name = "MedSci Foyer";
-	req_one_access_txt = "47"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "uhh" = (
@@ -55489,6 +56734,8 @@
 /area/medical/chemistry)
 "uhX" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "uid" = (
@@ -55502,7 +56749,9 @@
 /turf/open/floor/carpet,
 /area/library)
 "uif" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uip" = (
@@ -55519,6 +56768,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "uix" = (
@@ -55540,6 +56790,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/purple,
 /area/crew_quarters/heads/hor)
 "uiC" = (
@@ -55586,8 +56837,8 @@
 /turf/open/floor/plating/sandy_dirt,
 /area/crew_quarters/heads/chief)
 "ujC" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -55667,7 +56918,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ulq" = (
@@ -55992,11 +57249,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/ammo_casing/spent,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/item/ammo_casing/spent{
+	icon_state = "blshell"
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "uqv" = (
@@ -56066,15 +57325,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/crew_quarters/dorms)
-"urG" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "urN" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -56163,6 +57413,9 @@
 /area/crew_quarters/dorms)
 "utB" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "utE" = (
@@ -56251,6 +57504,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/security_space_law{
+	layer = 2.85;
+	pixel_x = 7;
+	pixel_y = -2
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "uvj" = (
@@ -56329,7 +57587,7 @@
 "uwx" = (
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "uwD" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 1
@@ -56435,7 +57693,7 @@
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "uyA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56468,6 +57726,9 @@
 	c_tag = "Atmospherics Monitoring";
 	dir = 4
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uyX" = (
@@ -56475,6 +57736,7 @@
 /obj/effect/turf_decal/weather,
 /obj/structure/lattice,
 /obj/structure/grille/broken,
+/obj/item/pickaxe/mini,
 /turf/open/floor/plating/rust,
 /area/chapel/office)
 "uzh" = (
@@ -56501,6 +57763,9 @@
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -56529,9 +57794,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "uAo" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/closed/wall,
 /area/engine/atmos)
 "uBp" = (
@@ -56757,6 +58020,9 @@
 	req_one_access_txt = "4"
 	},
 /obj/item/reagent_containers/food/drinks/flask/det,
+/obj/item/clothing/under/suit/white,
+/obj/item/clothing/shoes/jackboots/digitigrade,
+/obj/item/clothing/glasses/hud/security/sunglasses,
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "uEE" = (
@@ -56920,7 +58186,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "uGI" = (
 /obj/machinery/biogenerator,
@@ -57050,7 +58326,6 @@
 /area/engine/engineering)
 "uJd" = (
 /obj/structure/bookcase,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "uJl" = (
@@ -57087,6 +58362,10 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/office)
+"uJO" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "uKc" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -57111,8 +58390,8 @@
 /turf/open/floor/wood,
 /area/hallway/primary/port)
 "uKB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output,
-/turf/open/floor/engine/n2o,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrogen_input,
+/turf/open/floor/engine/n2,
 /area/engine/atmos)
 "uKQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -57193,6 +58472,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white/side,
 /area/medical/medbay/lobby)
 "uLN" = (
@@ -57224,6 +58504,13 @@
 	dir = 9
 	},
 /area/hallway/primary/central)
+"uLW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "uMo" = (
 /obj/item/toy/figure/md,
 /obj/structure/table,
@@ -57253,7 +58540,7 @@
 /area/hallway/primary/port)
 "uMN" = (
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "uMR" = (
 /obj/structure/cable,
 /obj/machinery/light{
@@ -57345,16 +58632,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/quartermaster/office)
-"uNR" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "uNZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -57395,10 +58672,10 @@
 /turf/open/floor/wood,
 /area/library)
 "uOu" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxin_output{
 	dir = 4
 	},
-/turf/open/floor/engine/o2,
+/turf/open/floor/engine/plasma,
 /area/engine/atmos)
 "uOy" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -57423,9 +58700,8 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "uOH" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "uOS" = (
@@ -57532,18 +58808,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "uPH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Plasma Outlet Pump"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uPJ" = (
@@ -57594,6 +58865,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/library)
+"uQh" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "uQj" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/lawyer,
@@ -57626,6 +58901,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uRd" = (
@@ -57662,14 +58938,14 @@
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "uRV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "uSi" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -57688,8 +58964,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "uSp" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -57731,8 +59008,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "uSQ" = (
@@ -57959,6 +59237,9 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = -28
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "uWg" = (
@@ -57967,6 +59248,14 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uWh" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "uWz" = (
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
@@ -57997,8 +59286,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/air_sensor/atmos/nitrogen_tank,
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "uXE" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -58057,6 +59345,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"uYm" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/library)
 "uYo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -58251,7 +59543,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "vce" = (
 /obj/item/bedsheet/centcom,
 /obj/structure/bed,
@@ -58350,6 +59642,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "vdK" = (
@@ -58375,9 +59670,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/dark,
 /area/science/research)
 "vei" = (
 /obj/machinery/door/airlock/security{
@@ -58385,7 +59678,7 @@
 	req_access_txt = "1"
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/checkpoint/auxiliary)
 "vey" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -58459,7 +59752,7 @@
 	name = "Private Study";
 	req_access_txt = "37"
 	},
-/turf/open/space/basic,
+/turf/open/floor/wood,
 /area/library)
 "vfX" = (
 /obj/machinery/microwave,
@@ -58751,6 +60044,9 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vkE" = (
@@ -58769,7 +60065,10 @@
 /area/tcommsat/server)
 "vkS" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/space/basic,
 /area/engine/atmos)
 "vlm" = (
@@ -58922,8 +60221,8 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -58986,6 +60285,10 @@
 	dir = 1
 	},
 /area/medical/medbay/central)
+"vpy" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/hallway/primary/central)
 "vpC" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -59083,6 +60386,9 @@
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plastic,
 /area/engine/break_room)
 "vqz" = (
@@ -59323,6 +60629,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/office/secretary)
+"vvo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/oxygen_output,
+/turf/open/floor/engine/o2,
+/area/engine/atmos)
 "vvN" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/holofloor/dark,
@@ -59790,7 +61100,7 @@
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/door/window/westleft{
 	name = "Crate Return";
-	req_access_txt = "31"
+	req_access_txt = "50"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -59895,7 +61205,7 @@
 /obj/machinery/shieldgen,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "vHk" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/lawyer,
@@ -59946,6 +61256,13 @@
 	},
 /turf/closed/wall,
 /area/maintenance/central)
+"vHR" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Pure to Port"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vHZ" = (
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
@@ -59961,6 +61278,7 @@
 /area/bridge/meeting_room/council)
 "vIt" = (
 /obj/machinery/door/airlock/command{
+	id_tag = "EVAdoors";
 	name = "EVA storage";
 	req_access_txt = "19"
 	},
@@ -59998,7 +61316,8 @@
 /area/science/xenobiology)
 "vJb" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/lawyer,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "vJe" = (
@@ -60094,8 +61413,9 @@
 /area/library)
 "vLe" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/kirbyplants/random{
+	pixel_y = 10
+	},
 /turf/open/floor/wood,
 /area/security/courtroom)
 "vLi" = (
@@ -60151,7 +61471,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "vLK" = (
-/obj/machinery/light{
+/obj/machinery/light/broken{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -60193,19 +61513,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -60389,10 +61705,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/kirbyplants/random,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "vPV" = (
@@ -60444,7 +61760,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "vQU" = (
-/turf/open/floor/engine/co2,
+/turf/open/floor/engine/air,
 /area/engine/atmos)
 "vRd" = (
 /obj/machinery/door/airlock/engineering{
@@ -60462,7 +61778,6 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "vRg" = (
-/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 5
@@ -60474,6 +61789,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "vRs" = (
@@ -60548,10 +61864,10 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "vRM" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
 /area/storage/tools)
 "vRV" = (
@@ -60816,6 +62132,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
+"vXk" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/vacant_room/commissary)
 "vXr" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -60830,10 +62150,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "vXs" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "vXO" = (
@@ -61065,7 +62382,7 @@
 /area/bridge)
 "wbk" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -61411,6 +62728,9 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "whG" = (
@@ -61459,8 +62779,8 @@
 "wiV" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -61780,6 +63100,12 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "woy" = (
@@ -61828,6 +63154,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "wqh" = (
@@ -61924,7 +63251,7 @@
 	c_tag = "Atmospherics East";
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wrQ" = (
@@ -61979,12 +63306,18 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
+"wsA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/dorms)
 "wsH" = (
 /obj/machinery/power/emitter,
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
-/area/engine/storage)
+/area/engine/storage_shared)
 "wsJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -62049,7 +63382,9 @@
 	},
 /area/security/courtroom)
 "wtq" = (
-/obj/machinery/power/floodlight,
+/obj/machinery/power/floodlight{
+	anchored = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/engine/engine_room)
@@ -62071,6 +63406,9 @@
 /area/tcommsat/server)
 "wtB" = (
 /obj/structure/closet/secure_closet/brig,
+/obj/structure/sign/poster/official/we_watch{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wtD" = (
@@ -62236,7 +63574,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "wvJ" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -62309,11 +63646,11 @@
 /turf/open/floor/holofloor/dark,
 /area/science/mixing)
 "wwm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -62412,8 +63749,8 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
 "wyf" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -62535,20 +63872,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "wAh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wAi" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -62585,14 +63911,15 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -62648,7 +63975,18 @@
 	name = "MedSci Foyer";
 	req_one_access_txt = "5"
 	},
-/turf/open/floor/plasteel/white,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "wBf" = (
 /obj/effect/turf_decal/tile/green{
@@ -62706,14 +64044,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "wCs" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wCt" = (
@@ -62736,13 +64074,6 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/science/xenobiology)
-"wCB" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "wCR" = (
 /obj/structure/reagent_dispensers/virusfood{
 	pixel_x = -32
@@ -62783,16 +64114,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/storage)
-"wDJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "wDQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -62836,6 +64157,8 @@
 	},
 /obj/item/aicard,
 /obj/item/ai_module/reset,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "wFe" = (
@@ -62942,11 +64265,8 @@
 /area/medical/medbay/central)
 "wGF" = (
 /obj/item/beacon,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "wGG" = (
@@ -62971,6 +64291,12 @@
 "wHh" = (
 /turf/open/floor/carpet,
 /area/library)
+"wHp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "wHt" = (
 /obj/structure/chair{
 	dir = 4
@@ -63013,8 +64339,8 @@
 /area/science/xenobiology)
 "wIt" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -63145,14 +64471,15 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "wJZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "CO2 Outlet Pump"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -63183,12 +64510,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "wLb" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
@@ -63219,11 +64545,20 @@
 /turf/open/floor/mineral/titanium,
 /area/janitor)
 "wLJ" = (
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "wLV" = (
@@ -63247,6 +64582,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
+"wMl" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "wMs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63269,11 +64610,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wMJ" = (
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
 "wMP" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/turf_decal/bot_white,
+/obj/item/clothing/shoes/jackboots,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "wMQ" = (
@@ -63304,18 +64647,21 @@
 "wNt" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/moth3{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wNx" = (
-/obj/structure/window/reinforced/spawner/west{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "wNH" = (
@@ -63442,7 +64788,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "wPe" = (
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "wPh" = (
 /obj/effect/landmark/start/janitor,
@@ -63515,6 +64861,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plastic,
 /area/engine/break_room)
 "wQb" = (
@@ -63543,6 +64892,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/machinery/airalarm/directional/east{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/pharmacy)
@@ -63635,8 +64987,7 @@
 /turf/closed/wall,
 /area/library)
 "wSq" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "wSu" = (
@@ -63930,7 +65281,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "wXJ" = (
-/turf/open/floor/engine/n2,
+/turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "wXM" = (
 /obj/effect/turf_decal/tile/red{
@@ -63967,6 +65318,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/bridge)
 "wYY" = (
@@ -64222,6 +65574,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"xdC" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xdH" = (
 /obj/item/flashlight/lamp/bananalamp,
 /obj/structure/table/wood,
@@ -64367,12 +65725,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/table/reinforced,
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/item/geiger_counter,
 /obj/item/clothing/glasses/meson,
 /obj/machinery/light,
+/obj/structure/table,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xgb" = (
@@ -64386,11 +65744,10 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "xgj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/carbon_input{
 	dir = 4
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine/air,
+/turf/open/floor/engine/co2,
 /area/engine/atmos)
 "xgG" = (
 /obj/effect/turf_decal/trimline/red/line,
@@ -64479,14 +65836,15 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "xhO" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "N2O Outlet Pump"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -64526,8 +65884,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "xiy" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air Outlet Pump"
+	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos)
 "xiC" = (
@@ -64579,8 +65940,9 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "xja" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2 to Pure"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -64692,12 +66054,11 @@
 	pixel_y = -32
 	},
 /obj/item/storage/briefcase/lawyer,
+/obj/item/stamp/law,
 /turf/open/floor/wood,
 /area/security/courtroom)
 "xmh" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xmk" = (
@@ -64848,6 +66209,7 @@
 	desc = "The Hyperspace navigation broke when the shuttle arrived, looks like it won't be moving any time soon.";
 	name = "Broken Navigation Console"
 	},
+/obj/item/modular_computer/laptop/preset,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/office/secretary)
 "xpK" = (
@@ -64947,25 +66309,6 @@
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/mineral/titanium/white,
 /area/crew_quarters/office/secretary)
-"xrM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "xrV" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -64984,18 +66327,19 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "xse" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Morgue";
-	req_access_txt = "6"
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/grunge{
+	name = "Morgue";
+	req_access_txt = null;
+	req_one_access_txt = "6;29"
+	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
 "xsj" = (
-/turf/open/floor/engine/plasma,
+/turf/open/floor/engine/o2,
 /area/engine/atmos)
 "xsm" = (
 /obj/machinery/computer/card/minor/ce{
@@ -65090,6 +66434,7 @@
 "xtB" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "xtN" = (
@@ -65112,6 +66457,7 @@
 /area/maintenance/disposal)
 "xtT" = (
 /obj/structure/chair/stool,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "xub" = (
@@ -65122,9 +66468,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "xue" = (
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_waste_output,
 /obj/structure/table,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/item/t_scanner,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "xur" = (
@@ -65655,10 +67001,10 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "xFb" = (
-/obj/structure/bookcase/random,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/library)
 "xFh" = (
@@ -65757,7 +67103,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xGv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xGy" = (
@@ -65847,6 +67196,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xIa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "xIb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -65873,6 +67235,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xIA" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	name = "plasma mixer"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xIH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -65932,6 +67300,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"xJj" = (
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
+/area/medical/psychology)
 "xJk" = (
 /obj/structure/fluff/hedge,
 /obj/structure/extinguisher_cabinet{
@@ -65961,6 +67333,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"xJH" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/engine/engine_room)
 "xJL" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -66058,6 +67435,7 @@
 "xMf" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/bot,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "xMg" = (
@@ -66216,9 +67594,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -66261,6 +67641,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/item/wallframe/newscaster,
 /turf/open/floor/plasteel/grimy,
 /area/storage/primary)
 "xOO" = (
@@ -66395,10 +67776,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xRO" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "xRT" = (
@@ -66581,7 +67960,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "xUu" = (
@@ -66622,13 +68000,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xVt" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
 "xVw" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -66639,12 +68010,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 8
-	},
+/turf/open/floor/plasteel/dark,
 /area/medical/medbay/lobby)
 "xWt" = (
 /obj/machinery/conveyor{
@@ -66807,25 +68173,6 @@
 	dir = 9
 	},
 /area/hallway/primary/central)
-"xYj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xYx" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -66841,6 +68188,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "xYV" = (
@@ -67089,18 +68439,18 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ycC" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ycL" = (
@@ -67305,19 +68655,19 @@
 /area/storage/emergency/port)
 "ygd" = (
 /obj/structure/fans/tiny,
-/obj/machinery/keycard_auth,
-/obj/structure/table,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/carbon,
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/office/secretary)
 "ygl" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "N2 Outlet Pump"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -67375,6 +68725,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "ygI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -81051,9 +82404,9 @@ lXW
 sbb
 nia
 fMK
-xCA
+xDJ
 ieX
-xCA
+xDJ
 pWw
 pWw
 xQP
@@ -81308,9 +82661,9 @@ sjZ
 sjZ
 nnT
 fMK
-aRD
+xxI
 lVt
-mHT
+xxI
 pWw
 xQP
 xQP
@@ -81567,7 +82920,7 @@ xDJ
 xxI
 xDJ
 sAn
-xCA
+xDJ
 pWw
 xQP
 xPt
@@ -82312,15 +83665,15 @@ nNy
 gpa
 rPG
 xgj
-wPe
+tlR
 jqC
 rPG
 ceB
-nyo
+pgd
 uOu
 rPG
 iYv
-wXJ
+mKr
 hSh
 rPG
 tWR
@@ -82570,7 +83923,7 @@ qjB
 rPG
 uzr
 jxr
-uzr
+bCU
 rPG
 uzr
 jxr
@@ -82586,11 +83939,11 @@ nHz
 vYd
 unW
 mUI
-vHZ
+eaC
 vHZ
 rUi
 vHZ
-vHZ
+eaC
 kCD
 sbD
 nHz
@@ -82820,14 +84173,14 @@ ojb
 ojb
 tfo
 ojb
-ojb
+uLW
 aky
 rgw
 cDN
-hRc
+huf
 cbC
 iJs
-cbC
+gBe
 fMK
 cbC
 iJs
@@ -83077,23 +84430,23 @@ rPG
 rPG
 rPG
 rPG
-fMK
+gHL
 wwm
 eFd
 chk
-nvj
-cwh
-uOH
-cwh
-tRj
-cwh
-uOH
+ceS
+cps
+csP
+ctL
+ceS
+cps
+cEG
 cHz
-tRj
+huf
 cwh
 uOH
 ijK
-hRc
+huf
 huf
 xDJ
 nJZ
@@ -83334,21 +84687,21 @@ vQU
 vQU
 arf
 wSq
-rME
+wIt
 oxD
 fBp
 daa
 rpS
 gtn
 uvP
-dYg
+kuv
 sCs
 gtn
-uvP
-egp
+cML
+kuv
 oha
 gtn
-jlm
+uvP
 kuv
 loU
 prQ
@@ -83589,7 +84942,7 @@ pWw
 rPG
 oCw
 ecn
-vQU
+qYQ
 jxr
 uSi
 laZ
@@ -83597,13 +84950,13 @@ xiy
 fFp
 fSn
 ktU
-frB
+qQb
 sUa
 qQb
-ktU
-bEQ
+jSd
+cNh
 pip
-kNB
+qQb
 oPw
 dmS
 rNu
@@ -83847,24 +85200,24 @@ rPG
 vQU
 vQU
 heS
-rAE
+wSq
 wIt
 qMf
 deC
 wJZ
-qkN
+uSp
 slA
 etr
-uSp
-nyV
-lRA
-cHE
-lrI
-lrI
+iqR
+vXs
+vXs
+cUf
+xIA
+vXs
 fPA
 mbq
 gWy
-loU
+iSN
 prQ
 xDJ
 nUl
@@ -84111,17 +85464,17 @@ nJq
 cHH
 prg
 akB
-akB
-ebt
-ebt
-oam
+kfw
+aMT
 xmh
-bNa
-bNa
-aeQ
+xmh
+djG
+rZy
+vHR
+ngD
 prG
 eCk
-jQn
+uQh
 pWw
 xDJ
 oag
@@ -84360,23 +85713,23 @@ fMK
 rPG
 xsj
 xsj
-xsj
-rPG
-itw
+vvo
+abD
+vkS
 ycC
 juC
 pjv
-bxY
+uSp
 rBN
 ujC
-gJv
-gJv
-ujC
-gJv
-gJv
-gJv
-gNq
-prG
+hVb
+gZs
+rZy
+xmh
+cUF
+rZy
+hkb
+kpe
 wiV
 pUz
 prQ
@@ -84618,24 +85971,24 @@ rPG
 oTk
 mYG
 nhr
-mSL
+jxr
 jfU
 rhJ
 iZl
 pet
-bxY
+bfR
 iOL
 sEW
-ebt
-ebt
-ebt
-ebt
-ebt
-ebt
-ebt
+oBM
+bNa
+soW
+dmB
+xdC
+llB
+hkb
 kpe
 pyL
-jQn
+dzE
 xDJ
 xDJ
 obb
@@ -84644,7 +85997,7 @@ aYc
 cem
 sRw
 xJD
-jak
+dxA
 uVX
 qUz
 qwA
@@ -84875,18 +86228,18 @@ rPG
 xsj
 xsj
 fzk
-rAE
+abD
 vkS
-qMf
-deC
+ycC
+bpk
 uPH
-qkN
-juc
+cFw
+bNa
 iDC
 xja
-rZy
-rZy
-rZy
+gZs
+xmh
+xmh
 rZy
 dHF
 jxh
@@ -84937,7 +86290,7 @@ fMK
 fMK
 pWw
 xcN
-wkf
+jHj
 xcN
 xcN
 fMK
@@ -85133,23 +86486,23 @@ rPG
 rPG
 rPG
 rPG
-fMK
+gHL
 epQ
 ddh
 eRA
-bxY
-iOL
-iDC
+bfR
+sot
+wMl
 wyf
-kyb
-trc
-tBm
+bNa
+bNa
+bNa
 llB
 hTY
 onB
 ljZ
 iRZ
-iKL
+scW
 iKL
 iKL
 oAq
@@ -85389,24 +86742,24 @@ rPG
 pEz
 pEz
 dfX
-wSq
-jfU
-ycC
+glQ
+pei
+ssA
 juC
 ygl
 uSp
 ctO
 esG
 iGL
-lrI
-qvd
-eKa
+xmh
+xmh
+xmh
 qwl
 tIF
 rRa
 uSO
 sHp
-yjq
+jcZ
 oLQ
 wcT
 yjq
@@ -85645,21 +86998,21 @@ pWw
 rPG
 oJc
 iOd
-pEz
+gbx
 jxr
-iJs
+jqa
 gcz
 gqQ
 rVg
 xGv
 vXs
-eie
+ngD
 tsN
 gPD
-xGv
-ezW
+bNa
+bNa
 lga
-hWS
+tIF
 cNE
 hLw
 neH
@@ -85903,24 +87256,24 @@ rPG
 pEz
 pEz
 uKB
-rAE
-vkS
-qMf
-deC
+abD
+eXD
+ycC
+bpk
 xhO
 gJv
 uif
-iDC
-arq
-llB
-rZy
+ggk
+ggk
+fak
+ggk
 ggk
 bBM
 bre
 aJl
 iZd
 tZj
-yjq
+jcZ
 lLv
 utF
 yfi
@@ -86164,15 +87517,15 @@ rPG
 fMK
 epQ
 hTJ
-cHH
+djN
 jOb
 gNq
-iDC
+cJz
 mEz
-wyf
-wyf
-iOL
-bNa
+kAY
+cJz
+epY
+kzr
 jSa
 wNx
 sSE
@@ -86417,36 +87770,36 @@ rPG
 cGQ
 cGQ
 dQb
-wSq
-jfU
-ycC
-lfV
+abD
+kJB
+fXK
+uOH
 hcT
 sos
-sos
-izK
+kcQ
+nDi
 pfM
 msE
-msE
+jtZ
 sZi
-jch
+vnF
 vnF
 ygI
 nfL
 qgp
-yjq
+jcZ
 jFU
 rlm
 yjq
 wNt
 sfw
-xDJ
+jaP
 xDJ
 jrc
 uao
 kVB
 xDJ
-xDJ
+jaP
 vdK
 lbz
 iyT
@@ -86673,25 +88026,25 @@ pWw
 rPG
 tUd
 cGQ
-cGQ
+rif
 jxr
-iJs
-gcz
-gqQ
+jAG
+ycC
+bej
 osD
 ngD
 ebt
 kuZ
 jaN
 pVp
-pVp
+xRO
 uAo
-nMa
+xRO
 xRO
 dIE
 acX
 qSV
-yjq
+hUY
 tIf
 tIf
 yjq
@@ -86902,7 +88255,7 @@ jRw
 xXB
 esL
 rnr
-mOI
+aFx
 oKM
 xXB
 fMK
@@ -86931,15 +88284,15 @@ rPG
 cGQ
 cGQ
 pbm
-rAE
-vkS
-qMf
-deC
+abD
+eXD
+ycC
+bpk
 gcR
-gJv
-gJv
-aqO
-xOg
+hnm
+phS
+bNa
+gFE
 tJw
 lPQ
 hUC
@@ -86956,7 +88309,7 @@ cWJ
 oIS
 ikD
 tCy
-iyT
+jIo
 lvA
 iyT
 bih
@@ -86977,9 +88330,9 @@ coT
 jbo
 yio
 oNY
-oNY
+xJH
 xQP
-xCA
+xQP
 pWw
 pWw
 pWw
@@ -87201,7 +88554,7 @@ kJH
 bje
 wGF
 dbz
-kJH
+itP
 gIa
 hmo
 xOu
@@ -87214,8 +88567,8 @@ kdg
 lgn
 tgw
 oCK
+lgn
 iUb
-iap
 uQT
 tNQ
 lIU
@@ -87226,16 +88579,16 @@ xnd
 xnd
 oNa
 fVk
-ezf
-xDJ
-xDJ
-xQP
+oNa
+xnd
+xnd
+eJs
 pyx
 xQP
 xQP
 xQP
 xQP
-deL
+xQP
 pWw
 pWw
 fMK
@@ -87464,14 +88817,14 @@ eWc
 qkZ
 lhz
 bmt
-bmt
+dpw
 oIl
 cWJ
 nqF
 wRD
 bAj
 tny
-tCR
+gIe
 aHU
 xtT
 aqF
@@ -87709,16 +89062,16 @@ fMK
 fMK
 wou
 rzd
-rzd
+gnN
 oUr
-rzd
-rzd
+jWp
+gnN
 uhX
-uhX
+oJH
 uhX
 uhX
 kOq
-wkg
+oVT
 dit
 wkg
 wkg
@@ -87728,8 +89081,8 @@ cSw
 tCR
 wSe
 wCs
-tsC
-jMA
+pvL
+hxO
 pvL
 hxO
 wMQ
@@ -87985,7 +89338,7 @@ bYs
 wnt
 uYo
 rVj
-pvL
+dxW
 oRb
 gNy
 cQB
@@ -88000,9 +89353,9 @@ chM
 rqe
 avk
 xnd
-faQ
+fDc
 xcy
-wGG
+fcI
 deL
 dDY
 oIt
@@ -88171,7 +89524,7 @@ asn
 aJj
 cmW
 bzU
-bFA
+aRD
 gQT
 dRm
 eon
@@ -88509,12 +89862,12 @@ aIN
 urP
 xDJ
 ieL
-swP
+eoV
 niX
-wGG
+ezj
 vca
-xZm
-xZm
+vap
+vap
 xcy
 xZm
 uLN
@@ -88766,11 +90119,11 @@ jFM
 urP
 xDJ
 bqJ
-xVt
+iaG
 ddm
-ddm
-xTJ
-pdZ
+eAY
+nxL
+ala
 iCC
 xcy
 nqG
@@ -89009,7 +90362,7 @@ qbe
 sSC
 pmQ
 yfP
-mHC
+kfX
 nOA
 pFB
 tlL
@@ -89027,8 +90380,8 @@ agB
 uwx
 sTb
 uyw
-xZm
-xZm
+vap
+vap
 xcy
 xZm
 fbv
@@ -89256,13 +90609,13 @@ fVW
 fMK
 fMK
 fMK
-xnd
-xnd
-xnd
-xnd
-xnd
-xnd
-xnd
+bDC
+bDC
+bDC
+bDC
+bDC
+bDC
+bDC
 xfA
 ulp
 uUp
@@ -89279,13 +90632,13 @@ xDJ
 xDJ
 xDJ
 xDJ
-xZm
-xZm
-xZm
-xZm
-xZm
-xZm
-uGp
+vap
+vap
+vap
+vap
+vap
+vap
+eMm
 xcy
 xZm
 xZm
@@ -89464,14 +90817,14 @@ iGU
 fub
 gBS
 szp
-hfi
+ezW
 aBS
 xXB
 xXB
 xXB
 xXB
 loA
-rnr
+ble
 qyH
 xXB
 xXB
@@ -89513,25 +90866,25 @@ jQj
 pXo
 ePv
 fMK
-xnd
+bDC
 fKc
 pMn
 gdi
 aiX
 nXR
-xnd
+bDC
 mNm
-dsy
+dsc
 ykj
 kHs
 uKc
 xsm
 uUp
 xTJ
-xTJ
-xTJ
-xTJ
-xTJ
+dBY
+dNf
+dSn
+dVX
 xTJ
 xTJ
 xTJ
@@ -89770,7 +91123,7 @@ yfJ
 bwr
 pXo
 fMK
-xnd
+bDC
 fhc
 qdj
 mws
@@ -89794,12 +91147,12 @@ wSj
 wSj
 wSj
 wSj
-wSj
-wSj
-wSj
+enn
+enn
+enn
 wSj
 xIz
-wGG
+eOc
 mHI
 xZm
 vCD
@@ -89985,7 +91338,7 @@ jrj
 ivt
 xXB
 opH
-rnr
+ble
 mUm
 xXB
 otn
@@ -90027,7 +91380,7 @@ caN
 pXo
 ugy
 pWw
-xnd
+bDC
 djY
 uMN
 uMN
@@ -90050,11 +91403,11 @@ qid
 qoO
 cBL
 fFH
-wSj
+enn
 eTP
 lCa
 jlx
-wSj
+enn
 xIz
 wGG
 qPp
@@ -90238,7 +91591,7 @@ rFD
 eSn
 aBS
 iwe
-jrj
+pio
 iwe
 xXB
 lpA
@@ -90284,7 +91637,7 @@ gcm
 lvu
 ugy
 pWw
-xnd
+bDC
 tqu
 uRz
 uRz
@@ -90307,11 +91660,11 @@ lgP
 rua
 wHh
 rXL
-wSj
+enn
 xhp
 ptD
 egS
-wSj
+enn
 xIz
 dzG
 qIe
@@ -90497,7 +91850,7 @@ aBS
 eUx
 jrj
 vxW
-kDM
+xSl
 lsz
 lUL
 mVj
@@ -90541,18 +91894,18 @@ cfN
 iqx
 pXo
 fMK
-xnd
+bDC
 vHj
 vHj
 vHj
 oGB
 rFy
-xnd
+bDC
 gBf
 mmZ
 ykj
 kOg
-ths
+egr
 aUk
 uUp
 xTJ
@@ -90564,11 +91917,11 @@ kJu
 jcl
 kkz
 vLd
-wSj
+enn
 awX
 sbO
 iae
-wSj
+enn
 xIz
 xZm
 xZm
@@ -90777,13 +92130,13 @@ nPr
 xOb
 xSb
 gbf
-qff
+lrq
 xsx
 ods
 vaA
 myM
 uSL
-uVT
+lBq
 wxb
 pVc
 uiC
@@ -90798,13 +92151,13 @@ cfN
 iqx
 pXo
 pWw
-xnd
-xnd
-xnd
-xnd
-xnd
-xnd
-xnd
+bDC
+bDC
+bDC
+bDC
+bDC
+bDC
+bDC
 mKq
 mmZ
 ykj
@@ -90822,9 +92175,9 @@ uid
 gtc
 efZ
 wSj
-wSj
+enn
 vfT
-wSj
+enn
 wSj
 xIz
 xZm
@@ -90844,7 +92197,7 @@ xHl
 xHl
 xHl
 xHl
-och
+fqO
 rDb
 uSk
 dSM
@@ -91334,7 +92687,7 @@ wHh
 ldZ
 wHh
 cNN
-uNK
+edi
 azw
 uEt
 dHM
@@ -91346,7 +92699,7 @@ hBX
 uuO
 wqq
 rad
-uuO
+kSp
 uuO
 wGG
 xTJ
@@ -91571,13 +92924,13 @@ ugy
 pWw
 yfP
 wQa
-ygv
+tGj
 bRt
 sUv
 rUn
 nNQ
 mKq
-mmZ
+dsW
 uUp
 uUp
 uUp
@@ -91587,7 +92940,7 @@ oaA
 wSj
 apz
 uNK
-uNK
+uYm
 uOp
 bsv
 uQf
@@ -91781,7 +93134,7 @@ pIf
 vGc
 iDu
 cCr
-hku
+awo
 vGc
 pxw
 vGc
@@ -91852,9 +93205,9 @@ wSj
 wSj
 wSj
 wSj
+enn
 wSj
-wSj
-xIz
+rnV
 xZm
 xZm
 wNj
@@ -92106,11 +93459,11 @@ wSj
 rVp
 cNN
 vKH
-rnu
 fef
-tbh
+fef
+wHh
 tsZ
-wSj
+enn
 xIz
 pWF
 dnQ
@@ -92307,7 +93660,7 @@ pyv
 qdK
 qFt
 pxw
-tii
+aaN
 stM
 tii
 pxw
@@ -92367,7 +93720,7 @@ tME
 qcq
 wHh
 qKL
-wSj
+enn
 vSv
 pWF
 vJq
@@ -92550,7 +93903,7 @@ eUf
 eSO
 eSO
 eUf
-iFF
+ags
 qrv
 keU
 hah
@@ -92624,7 +93977,7 @@ uNK
 uNK
 wHh
 eWu
-wSj
+enn
 xIz
 pWF
 dnQ
@@ -92789,8 +94142,8 @@ fMK
 nFm
 acK
 pWw
-fMK
-fMK
+aaZ
+pWw
 fMK
 fMK
 fMK
@@ -92877,13 +94230,13 @@ jhC
 wHh
 qtz
 uNK
-uNK
+uYm
 uNK
 wHh
 ezX
 wSj
-xIz
-xZm
+rnV
+eOC
 xZm
 xZm
 iHe
@@ -92896,7 +94249,7 @@ pTB
 xZm
 bWF
 xHl
-oaT
+xHl
 xHl
 xHl
 xHl
@@ -93316,7 +94669,7 @@ pWw
 pWw
 fMK
 eSO
-gvM
+abr
 fPe
 gvM
 hla
@@ -93343,7 +94696,7 @@ sYL
 qUb
 dEJ
 xvS
-oSb
+xPa
 gWJ
 hQD
 gSO
@@ -93411,8 +94764,8 @@ vCD
 bzR
 kPh
 mBO
-sml
 xHl
+fqD
 xHl
 xHl
 xHl
@@ -93600,7 +94953,7 @@ uMs
 ihf
 xvS
 xvS
-wCB
+uTc
 yjL
 vCa
 mvX
@@ -93646,14 +94999,14 @@ huf
 iYb
 ddJ
 wHh
-xFb
+ecu
 wSj
 wSj
 vCA
 wHh
 ezX
 wSj
-wGG
+eJa
 xGn
 iLh
 vIP
@@ -93857,7 +95210,7 @@ sYL
 qUb
 wnP
 xvS
-oSb
+xPa
 yjL
 xdZ
 lUU
@@ -93885,8 +95238,8 @@ pgu
 yfP
 fQR
 vsQ
-bWH
-sKM
+jgY
+swR
 kJN
 lvd
 qjb
@@ -93903,13 +95256,13 @@ huf
 oEa
 ddJ
 wHh
-xFb
+ecu
 wSj
 too
 uNK
 wHh
 ulu
-wSj
+enn
 cIV
 xGn
 lpD
@@ -94096,13 +95449,13 @@ auU
 jBv
 hah
 kME
-kWD
+ooW
 mdq
 rpq
 jKm
 wvR
 pOJ
-pAt
+jeg
 bVQ
 qJz
 rjK
@@ -94114,7 +95467,7 @@ mkN
 bet
 wnQ
 xvS
-oSb
+xPa
 yjL
 fcY
 fUP
@@ -94165,8 +95518,8 @@ mZy
 uNK
 uNK
 wHh
-qKL
-wSj
+eDz
+enn
 xGn
 xGn
 sbt
@@ -94371,7 +95724,7 @@ sYL
 qUb
 wqy
 xvS
-oSb
+xPa
 yjL
 vZz
 pOs
@@ -94423,7 +95776,7 @@ vmd
 skb
 rLt
 uZx
-wSj
+enn
 xGn
 wsN
 ort
@@ -94628,11 +95981,11 @@ uMs
 rub
 xvS
 xvS
-oSb
+xPa
 yjL
 kKI
 pLT
-hFB
+kPz
 pLT
 vsT
 vby
@@ -94679,7 +96032,7 @@ xGn
 xGn
 xGn
 xGn
-xGn
+eIa
 xGn
 wdJ
 dPd
@@ -94921,7 +96274,7 @@ utE
 mQj
 huf
 nDi
-huf
+dwE
 dRU
 tNd
 gJy
@@ -95142,7 +96495,7 @@ sYL
 qUb
 tnc
 xvS
-oSb
+xPa
 yjL
 bRN
 pLT
@@ -95656,16 +97009,16 @@ pVG
 wVt
 oHW
 wWt
-oSb
+xPa
 cgM
-oSb
-oSb
-oSb
-oSb
+xPa
+xPa
+xPa
+xPa
 uis
-wCB
-sAY
-sAY
+uTc
+yjc
+bLG
 vQu
 xPb
 qjS
@@ -95965,14 +97318,14 @@ dEc
 rEI
 ssw
 ukh
-hHd
+hCa
 nma
 lCG
 tPf
 rEI
 fsU
 hHd
-rEI
+dEw
 yaa
 xGn
 auL
@@ -96194,7 +97547,7 @@ urN
 xXW
 dcd
 auD
-auD
+dZa
 auD
 eMk
 juQ
@@ -96471,7 +97824,7 @@ jmh
 oyX
 lDe
 qAJ
-sNa
+vpy
 sNa
 wjt
 jsw
@@ -96691,7 +98044,7 @@ wxh
 lop
 uwe
 jAw
-uwe
+bIx
 qZP
 ktE
 qsj
@@ -96955,7 +98308,7 @@ qsj
 nwC
 rXG
 sqk
-sDG
+vXk
 sDG
 jON
 jON
@@ -97210,7 +98563,7 @@ uxF
 ktE
 qsj
 rPh
-rXG
+bUm
 moz
 jON
 cYs
@@ -97244,7 +98597,7 @@ kwc
 usP
 xTJ
 xTJ
-xTJ
+cYo
 xTJ
 xTJ
 xTJ
@@ -97253,14 +98606,14 @@ xTJ
 xGn
 cxx
 dCv
-nax
-xCB
+eVZ
+fht
 ceU
 kZX
 xGn
 aHK
 dvy
-vpG
+fiL
 xTJ
 cHr
 xPB
@@ -97489,7 +98842,7 @@ pPe
 vjV
 rSH
 fmX
-pJk
+dug
 wLI
 fjx
 fjx
@@ -97512,7 +98865,7 @@ xGn
 gcN
 uJd
 uJd
-bwj
+dsu
 dsu
 xGn
 jmq
@@ -97945,7 +99298,7 @@ fMK
 pxw
 fZk
 gIp
-gHr
+hRc
 hXh
 iQF
 ylJ
@@ -98021,7 +99374,7 @@ cKO
 wip
 xkk
 xTJ
-xTJ
+rlG
 xTJ
 xTJ
 xTJ
@@ -98038,7 +99391,7 @@ xPB
 wDH
 wDH
 vey
-oDz
+suW
 cQv
 cuo
 eFf
@@ -98727,7 +100080,7 @@ uuR
 nvm
 nXk
 oLG
-oLG
+nPi
 pFL
 qoH
 pxw
@@ -98736,8 +100089,8 @@ tii
 sBU
 yae
 tSL
-goC
-goC
+blr
+blr
 prY
 wXY
 bGo
@@ -98750,7 +100103,7 @@ kDQ
 gtG
 gvh
 ktE
-pve
+qsj
 pUS
 pUS
 pUS
@@ -98965,7 +100318,7 @@ fMK
 bPu
 bbA
 dfF
-dZm
+aSS
 dZm
 nbM
 kTE
@@ -98994,9 +100347,9 @@ pxw
 yae
 yae
 uPt
-qyo
+vLe
 ift
-goC
+boF
 xvo
 kDQ
 lxx
@@ -99007,7 +100360,7 @@ vYt
 juh
 uXE
 ktE
-pve
+qsj
 hpx
 vbP
 nBg
@@ -99047,7 +100400,7 @@ bpd
 aAt
 gZZ
 kbe
-uCe
+ooF
 uCe
 iTa
 jdn
@@ -99061,7 +100414,7 @@ nsd
 ixz
 wFB
 xTE
-wGG
+fXi
 xPB
 tGq
 tGq
@@ -99253,8 +100606,8 @@ tWi
 uQj
 xmf
 wtm
-goC
-goC
+bsx
+blr
 kDQ
 xUK
 vde
@@ -99264,7 +100617,7 @@ kDQ
 sWH
 qzw
 ktE
-pve
+qsj
 hpx
 sDo
 wLc
@@ -99297,7 +100650,7 @@ xNU
 xNU
 uob
 kwc
-wzJ
+dWt
 lVb
 pXJ
 pCD
@@ -99334,7 +100687,7 @@ dwG
 rdo
 wtL
 qYT
-nAa
+tKu
 nAa
 imT
 eAC
@@ -99510,18 +100863,18 @@ tWZ
 uQy
 vHk
 wuH
-gsG
+wHp
 gsG
 xSR
 gTB
-gTB
+cdq
 jWy
 aXz
 yae
 lGV
 qzw
 ktE
-pve
+iJi
 oWr
 vPu
 qLY
@@ -99767,8 +101120,8 @@ tXS
 uQj
 vJb
 wvm
-goC
-goC
+buE
+bog
 kDQ
 wnq
 wtn
@@ -99778,7 +101131,7 @@ kDQ
 sWH
 qzw
 dNN
-toq
+bMj
 eRe
 eoH
 ijh
@@ -100024,7 +101377,7 @@ yae
 uPt
 vLe
 gYC
-goC
+bwM
 xvo
 kDQ
 uzj
@@ -100062,13 +101415,13 @@ iKw
 spS
 xNU
 pir
-tQV
+bVV
 dih
 tCz
 tJr
 xhP
 kwc
-wzJ
+dWt
 ygZ
 aSi
 efD
@@ -100278,8 +101631,8 @@ roa
 roa
 yae
 tXV
-goC
-goC
+bog
+bog
 rUq
 wXY
 xxy
@@ -100325,7 +101678,7 @@ tCz
 tJr
 hfT
 kwc
-wzJ
+dYh
 vWG
 bHx
 tsQ
@@ -100549,7 +101902,7 @@ yae
 yae
 gdR
 ktE
-yhd
+bMR
 xuP
 xuP
 xuP
@@ -100806,7 +102159,7 @@ yae
 yae
 pPV
 ktE
-pve
+qsj
 dLN
 xKG
 oqU
@@ -100819,7 +102172,7 @@ ybP
 ybP
 ybP
 ybP
-oTp
+oNQ
 ybP
 ybP
 ybP
@@ -100839,7 +102192,7 @@ xNU
 xNU
 edk
 kwc
-wzJ
+dYD
 snT
 snT
 snT
@@ -101022,12 +102375,12 @@ fMK
 aUB
 euy
 cBM
-nhV
+cdo
 exI
 ign
 exI
 bBY
-jHh
+ezf
 kSS
 wuo
 kWW
@@ -101046,7 +102399,7 @@ lTt
 xBP
 xBP
 xBP
-xBP
+aZf
 xBP
 xBP
 xBP
@@ -101055,7 +102408,7 @@ uUX
 yjx
 xyj
 xTh
-vOt
+bDL
 vOt
 gDv
 ujv
@@ -101063,7 +102416,7 @@ iOZ
 lNY
 pPV
 ktE
-pve
+qsj
 dLN
 hWY
 eEA
@@ -101320,7 +102673,7 @@ iGA
 lNY
 pPV
 dNN
-toq
+bQX
 pCs
 eXw
 mSv
@@ -101825,7 +103178,7 @@ xBP
 uUX
 xcd
 xzs
-pku
+bDy
 khe
 uPq
 mwI
@@ -101841,7 +103194,7 @@ bEq
 fLm
 cVi
 xuP
-xDo
+cdL
 ore
 ybP
 qje
@@ -102091,7 +103444,7 @@ qjz
 ssg
 dvR
 dAP
-pve
+iJi
 xuP
 rxR
 eoh
@@ -102348,7 +103701,7 @@ qDp
 qDp
 qDp
 eSp
-pve
+qsj
 xuP
 xuP
 xuP
@@ -102605,7 +103958,7 @@ mEX
 mEX
 bYj
 lwn
-pve
+qsj
 vjV
 sgX
 jkh
@@ -102681,7 +104034,7 @@ ylQ
 ykW
 xmY
 hTk
-xmY
+fEG
 pBN
 vKw
 lby
@@ -103932,8 +105285,8 @@ vdZ
 vdZ
 vdZ
 qel
-wXU
-aIC
+fUq
+cOV
 xbF
 ojo
 rUj
@@ -104180,17 +105533,17 @@ tuN
 tMP
 dfr
 xEs
-xnw
-xnw
+kVV
+kVV
 jBC
 ruN
 oKa
 aZv
-aZv
-aZv
+erE
+erE
 nRi
-uDx
-pwU
+bmT
+gSm
 fiM
 jNo
 vEQ
@@ -104444,10 +105797,10 @@ xjj
 lBM
 wfh
 xjj
-urG
-mWe
+wfh
+xjj
 uhd
-xrM
+vyf
 vyf
 sBA
 rUj
@@ -104702,9 +106055,9 @@ wjj
 ihk
 llI
 iJK
-dBs
+pjp
 bmT
-uNR
+vyf
 vyf
 ahP
 rUj
@@ -104927,7 +106280,7 @@ uxY
 uxY
 uxY
 gnB
-wrn
+uWh
 nuf
 ngz
 jvF
@@ -104943,7 +106296,7 @@ pmU
 gnX
 iKE
 owR
-gnB
+dHw
 wrn
 uxY
 uxY
@@ -104957,11 +106310,11 @@ vRB
 piy
 bWp
 nkj
-xjj
+rNx
 fjl
-nCS
+xjj
 tpL
-qNU
+aWV
 aWV
 fKE
 oYj
@@ -105214,11 +106567,11 @@ rNX
 sSz
 khU
 nhs
-llI
+hBl
 qIx
 pjp
 roI
-wDJ
+lIt
 lIt
 vrO
 oYj
@@ -105472,10 +106825,10 @@ xjj
 upH
 wfh
 xjj
-ghA
-aSS
+wfh
+xjj
 wLJ
-cdo
+lIt
 lIt
 eRZ
 oYj
@@ -105722,8 +107075,8 @@ tuN
 mZW
 dfr
 fjc
-xnw
-xnw
+kVV
+kVV
 tLp
 wAW
 dHr
@@ -105731,8 +107084,8 @@ tnM
 tnM
 tnM
 pEr
-xKt
-ivv
+roI
+eYs
 fDa
 wNr
 xmV
@@ -105984,11 +107337,11 @@ sRY
 ePz
 uGH
 xVw
-fWt
-fWt
-fWt
+qoD
+qoD
+qoD
 gak
-xqg
+xIa
 vMH
 rFn
 fGv
@@ -106247,7 +107600,7 @@ xqg
 xKt
 xKt
 wAk
-mNY
+qXA
 qFf
 xmV
 aMx
@@ -106947,7 +108300,7 @@ jMg
 eho
 wXm
 qqb
-xYj
+nfz
 qqb
 tUC
 uSA
@@ -106956,7 +108309,7 @@ qqb
 fkZ
 qqb
 uUs
-qqb
+aXs
 xOx
 tsH
 upG
@@ -107010,7 +108363,7 @@ khm
 wth
 ktz
 wIx
-wIx
+ppc
 wIx
 uLC
 mdD
@@ -107241,7 +108594,7 @@ gIn
 sCr
 gYO
 nmR
-nmR
+csS
 aFq
 eeC
 gUk
@@ -107267,7 +108620,7 @@ rEn
 xqg
 ktz
 wIx
-wIx
+igN
 wIx
 uFs
 xqg
@@ -108063,7 +109416,7 @@ kKv
 vyH
 wJO
 ilk
-wJO
+omk
 wJO
 upE
 qlO
@@ -108823,7 +110176,7 @@ qAl
 lOO
 bxa
 ska
-jvM
+sJm
 wtc
 lRt
 rwR
@@ -109281,7 +110634,7 @@ lCU
 xCs
 nzo
 bIo
-yig
+lww
 yig
 yig
 yig
@@ -110365,7 +111718,7 @@ pGY
 jaK
 tvU
 dem
-jNz
+xJj
 uqb
 mWA
 tvU
@@ -110826,7 +112179,7 @@ wcI
 nCl
 kVo
 doW
-doW
+oqX
 gKo
 hgI
 tQr
@@ -110893,7 +112246,7 @@ sHV
 oVy
 iRE
 cmM
-xIb
+fug
 dyj
 sRQ
 kwS
@@ -111072,7 +112425,7 @@ oqz
 xZu
 tCQ
 xZu
-tqp
+wsA
 vVB
 wFK
 oXe
@@ -111084,7 +112437,7 @@ egc
 nLE
 ego
 exH
-nLE
+azG
 nLE
 vtm
 lyA
@@ -111298,7 +112651,7 @@ fMK
 fMK
 pWw
 aBr
-wlR
+aqO
 wlR
 bTN
 aqe
@@ -111647,7 +113000,7 @@ hAL
 fBN
 gyO
 oQG
-txB
+qpq
 txB
 wnf
 jiP
@@ -111854,7 +113207,7 @@ nJY
 jqp
 eKQ
 cUJ
-jNH
+cUJ
 muz
 nLE
 adB
@@ -111894,7 +113247,7 @@ fMK
 wJk
 gta
 mgr
-mgr
+bQk
 mgr
 cQx
 wJk
@@ -112339,7 +113692,7 @@ gif
 gYe
 hHC
 aqe
-jbI
+amh
 oXe
 kzn
 kzn
@@ -114470,7 +115823,7 @@ tYk
 dXL
 jTi
 htx
-iOs
+uJO
 mdl
 cod
 lij


### PR DESCRIPTION
## About The Pull Request
Reworks the atmos area to be easier to comprehend, and to no longer cause a stroke in engineer mains upon the mere sight of the spaghetti pipes.
Also performs more bugfixes to the map, (hopefully) finally bringing it to a smooth playable state.
## Why It's Good For The Game
"Look at my works ye mighty, and despair"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more map fluff
tweak: Replaced the entire atmos area
fix: fixed a lot of stuff nobody cares about (not like curators need a breathable office anyways)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
