### PR TITLE
The Wallening Approacheth: Adds directional variants to most wall mounts [PORT]

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5151,7 +5151,9 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
 "ny" = (
-/obj/machinery/light/dim/directional/west,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
 "nz" = (
@@ -5172,10 +5174,12 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
 "nD" = (
@@ -6135,6 +6139,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6145,7 +6152,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "pi" = (
@@ -7040,18 +7046,24 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership/control)
 "qN" = (
-/obj/structure/urinal/directional/north,
+/obj/structure/urinal{
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "qO" = (
 /obj/item/soap/syndie,
 /obj/structure/mopbucket,
-/obj/machinery/light/small/directional/north,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "qP" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/item/mop,
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "qQ" = (
@@ -7146,11 +7158,13 @@
 /area/syndicate_mothership)
 "re" = (
 /obj/item/paper/fluff/stations/centcom/disk_memo,
+/obj/structure/noticeboard{
+	pixel_x = -32
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/noticeboard/directional/west,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "rf" = (
@@ -7189,11 +7203,13 @@
 /turf/open/floor/carpet/royalblack,
 /area/centcom)
 "rj" = (
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "rk" = (
@@ -7656,7 +7672,9 @@
 /turf/open/floor/grass,
 /area/centcom/evac)
 "rW" = (
-/obj/machinery/light/dim/directional/west,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "rX" = (
@@ -7710,11 +7728,13 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "se" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/machinery/light/dim/directional/west,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "sf" = (
@@ -9945,13 +9965,16 @@
 /turf/open/floor/wood,
 /area/wizard_station)
 "wN" = (
-/obj/machinery/light/small/directional/west{
-	brightness = 3
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "wO" = (
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "wP" = (
@@ -10441,7 +10464,9 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/light/dim/directional/west,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/centcom/holding)
 "ye" = (
@@ -13441,8 +13466,9 @@
 /turf/open/floor/plasteel,
 /area/wizard_station)
 "Eb" = (
-/obj/machinery/light/small/directional/west{
-	brightness = 3
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
@@ -13452,18 +13478,23 @@
 /turf/open/floor/carpet,
 /area/wizard_station)
 "Ed" = (
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/wizard_station)
 "Ee" = (
 /obj/item/soap/homemade,
-/obj/machinery/light/small/directional/west{
-	brightness = 3
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/wizard_station)
 "Ef" = (
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/wizard_station)
 "Eg" = (
@@ -13488,7 +13519,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small/directional/south,
+/obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/wizard_station)
 "Ek" = (
@@ -14832,10 +14863,12 @@
 	dir = 4;
 	pixel_x = -12
 	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Hc" = (
@@ -14884,10 +14917,12 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Hi" = (
@@ -14940,7 +14975,9 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror/directional/west,
+/obj/structure/mirror{
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Ho" = (
@@ -15069,7 +15106,9 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror/directional/east,
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Hz" = (
@@ -15086,10 +15125,12 @@
 	dir = 4;
 	pixel_x = -12
 	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HB" = (
@@ -15143,8 +15184,10 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/effect/turf_decal/tile/green,
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HG" = (
@@ -15163,13 +15206,15 @@
 	dir = 4;
 	pixel_x = -12
 	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HJ" = (
@@ -15292,11 +15337,13 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HS" = (
@@ -16763,7 +16810,9 @@
 /turf/open/floor/plating,
 /area/centcom/evac)
 "KR" = (
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/centcom/evac)
 "KS" = (
@@ -16812,7 +16861,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "KZ" = (
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/centcom/evac)
 "La" = (
@@ -18058,6 +18109,13 @@
 /turf/open/floor/wood,
 /area/centcom/testchamber)
 "OJ" = (
+/obj/machinery/button/door{
+	id = "testvent";
+	name = "Testing Chamber Vent Control";
+	pixel_x = -25;
+	pixel_y = 5;
+	req_access_txt = "7"
+	},
 /obj/machinery/button/ignition{
 	id = "mixingsparker";
 	pixel_x = -25;
@@ -18065,12 +18123,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/orion_ship,
-/obj/machinery/button/door/directional/west{
-	id = "testvent";
-	name = "Testing Chamber Vent Control";
-	pixel_y = 5;
-	req_access_txt = "7"
-	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "OK" = (
@@ -19310,6 +19362,9 @@
 /area/centcom/supplypod)
 "Sw" = (
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -19320,7 +19375,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/light/dim/directional/west,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "Sy" = (
@@ -19638,7 +19692,9 @@
 /area/centcom)
 "TK" = (
 /obj/structure/table/wood/bar,
-/obj/structure/mirror/directional/north,
+/obj/structure/mirror{
+	pixel_y = 28
+	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "TL" = (
@@ -19917,10 +19973,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
-"UA" = (
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/wood,
-/area/centcom/holding)
 "UC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20316,7 +20368,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "VA" = (
-/obj/machinery/light/dim/directional/west,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "VF" = (
@@ -20499,8 +20553,9 @@
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "Wj" = (
-/obj/machinery/light/small/directional/west{
-	brightness = 3
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
@@ -45977,10 +46032,10 @@ CV
 CT
 NT
 CT
-UA
+oV
 CT
 CT
-UA
+oV
 CT
 Nd
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5151,9 +5151,7 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
 "ny" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating,
 /area/syndicate_mothership/control)
 "nz" = (
@@ -5174,12 +5172,10 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/centcom/ferry)
 "nD" = (
@@ -6139,9 +6135,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -6152,6 +6145,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "pi" = (
@@ -7046,24 +7040,18 @@
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership/control)
 "qN" = (
-/obj/structure/urinal{
-	pixel_y = 28
-	},
+/obj/structure/urinal/directional/north,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "qO" = (
 /obj/item/soap/syndie,
 /obj/structure/mopbucket,
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "qP" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/item/mop,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "qQ" = (
@@ -7158,13 +7146,11 @@
 /area/syndicate_mothership)
 "re" = (
 /obj/item/paper/fluff/stations/centcom/disk_memo,
-/obj/structure/noticeboard{
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/structure/noticeboard/directional/west,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "rf" = (
@@ -7203,13 +7189,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/centcom)
 "rj" = (
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
 "rk" = (
@@ -7672,9 +7656,7 @@
 /turf/open/floor/grass,
 /area/centcom/evac)
 "rW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "rX" = (
@@ -7728,13 +7710,11 @@
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "se" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/plasteel,
 /area/syndicate_mothership/control)
 "sf" = (
@@ -9965,16 +9945,13 @@
 /turf/open/floor/wood,
 /area/wizard_station)
 "wN" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/machinery/light/small/directional/west{
+	brightness = 3
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "wO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "wP" = (
@@ -10464,9 +10441,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/grass,
 /area/centcom/holding)
 "ye" = (
@@ -13466,9 +13441,8 @@
 /turf/open/floor/plasteel,
 /area/wizard_station)
 "Eb" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/machinery/light/small/directional/west{
+	brightness = 3
 	},
 /turf/open/floor/carpet,
 /area/wizard_station)
@@ -13478,23 +13452,18 @@
 /turf/open/floor/carpet,
 /area/wizard_station)
 "Ed" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet,
 /area/wizard_station)
 "Ee" = (
 /obj/item/soap/homemade,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/machinery/light/small/directional/west{
+	brightness = 3
 	},
 /turf/open/floor/plasteel/white,
 /area/wizard_station)
 "Ef" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plasteel/white,
 /area/wizard_station)
 "Eg" = (
@@ -13519,7 +13488,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/small,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/plasteel,
 /area/wizard_station)
 "Ek" = (
@@ -14863,12 +14832,10 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Hc" = (
@@ -14917,12 +14884,10 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Hi" = (
@@ -14975,9 +14940,7 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Ho" = (
@@ -15106,9 +15069,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "Hz" = (
@@ -15125,12 +15086,10 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HB" = (
@@ -15184,10 +15143,8 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/green,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HG" = (
@@ -15206,15 +15163,13 @@
 	dir = 4;
 	pixel_x = -12
 	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HJ" = (
@@ -15337,13 +15292,11 @@
 	dir = 8;
 	pixel_x = 11
 	},
-/obj/structure/mirror{
-	pixel_x = 28
-	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/plasteel/white,
 /area/tdome/tdomeobserve)
 "HS" = (
@@ -16810,9 +16763,7 @@
 /turf/open/floor/plating,
 /area/centcom/evac)
 "KR" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/centcom/evac)
 "KS" = (
@@ -16861,9 +16812,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
 "KZ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/centcom/evac)
 "La" = (
@@ -18109,13 +18058,6 @@
 /turf/open/floor/wood,
 /area/centcom/testchamber)
 "OJ" = (
-/obj/machinery/button/door{
-	id = "testvent";
-	name = "Testing Chamber Vent Control";
-	pixel_x = -25;
-	pixel_y = 5;
-	req_access_txt = "7"
-	},
 /obj/machinery/button/ignition{
 	id = "mixingsparker";
 	pixel_x = -25;
@@ -18123,6 +18065,12 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/orion_ship,
+/obj/machinery/button/door/directional/west{
+	id = "testvent";
+	name = "Testing Chamber Vent Control";
+	pixel_y = 5;
+	req_access_txt = "7"
+	},
 /turf/open/floor/plasteel,
 /area/centcom/testchamber)
 "OK" = (
@@ -19362,9 +19310,6 @@
 /area/centcom/supplypod)
 "Sw" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -19375,6 +19320,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "Sy" = (
@@ -19692,9 +19638,7 @@
 /area/centcom)
 "TK" = (
 /obj/structure/table/wood/bar,
-/obj/structure/mirror{
-	pixel_y = 28
-	},
+/obj/structure/mirror/directional/north,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "TL" = (
@@ -19973,6 +19917,10 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
+"UA" = (
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "UC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -20368,9 +20316,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "VA" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
 "VF" = (
@@ -20553,9 +20499,8 @@
 /turf/open/floor/bluespace,
 /area/centcom/testchamber)
 "Wj" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/machinery/light/small/directional/west{
+	brightness = 3
 	},
 /turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership/control)
@@ -46032,10 +45977,10 @@ CV
 CT
 NT
 CT
-oV
+UA
 CT
 CT
-oV
+UA
 CT
 Nd
 aa

--- a/code/game/machinery/bounty_board.dm
+++ b/code/game/machinery/bounty_board.dm
@@ -19,6 +19,22 @@ GLOBAL_LIST_EMPTY(request_list)
 	///Text of the currently written bounty
 	var/bounty_text = ""
 
+/obj/machinery/bounty_board/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/bounty_board/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/bounty_board/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/bounty_board/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/machinery/bounty_board/Initialize(mapload, ndir, building)
 	. = ..()
 	GLOB.allbountyboards += src

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -187,6 +187,22 @@
 	var/specialfunctions = OPEN // Bitflag, see assembly file
 	var/sync_doors = TRUE
 
+/obj/machinery/button/door/directional/north
+	dir = SOUTH
+	pixel_y = 24
+
+/obj/machinery/button/door/directional/south
+	dir = NORTH
+	pixel_y = -24
+
+/obj/machinery/button/door/directional/east
+	dir = WEST
+	pixel_x = 24
+
+/obj/machinery/button/door/directional/west
+	dir = EAST
+	pixel_x = -24
+
 /obj/machinery/button/door/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -275,6 +275,22 @@
 	var/icon_state_off = "entertainment_blank"
 	var/icon_state_on = "entertainment"
 
+/obj/machinery/computer/security/telescreen/entertainment/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/computer/security/telescreen/entertainment/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/computer/security/telescreen/entertainment/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/computer/security/telescreen/entertainment/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/machinery/computer/security/telescreen/entertainment/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_CLICK, .proc/BigClick)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -18,9 +18,41 @@
 /// the type of wallframe it 'disassembles' into
 	var/wallframe_type = /obj/item/wallframe/defib_mount
 
+/obj/machinery/defibrillator_mount/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/defibrillator_mount/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/defibrillator_mount/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/defibrillator_mount/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/machinery/defibrillator_mount/loaded/Initialize() //loaded subtype for mapping use
 	. = ..()
 	defib = new/obj/item/defibrillator/loaded(src)
+
+/obj/machinery/defibrillator_mount/loaded/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/defibrillator_mount/loaded/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/defibrillator_mount/loaded/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/defibrillator_mount/loaded/directional/west
+	dir = EAST
+	pixel_x = -32
 
 /obj/machinery/defibrillator_mount/Destroy()
 	if(defib)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -17,6 +17,22 @@
 	var/strength = 100 //How knocked down targets are when flashed.
 	var/base_state = "mflash"
 
+/obj/machinery/flasher/directional/north
+	dir = SOUTH
+	pixel_y = 26
+
+/obj/machinery/flasher/directional/south
+	dir = NORTH
+	pixel_y = -26
+
+/obj/machinery/flasher/directional/east
+	dir = WEST
+	pixel_x = 26
+
+/obj/machinery/flasher/directional/west
+	dir = EAST
+	pixel_x = -26
+
 /obj/machinery/flasher/portable //Portable version of the flasher. Only flashes when anchored
 	name = "portable flasher"
 	desc = "A portable flashing device. Wrench to activate and deactivate. Cannot detect slow movements."

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -69,6 +69,22 @@
 	var/last_spark = 0
 	var/datum/effect_system/spark_spread/spark_system
 
+/obj/machinery/sparker/directional/north
+	dir = SOUTH
+	pixel_y = 26
+
+/obj/machinery/sparker/directional/south
+	dir = NORTH
+	pixel_y = -26
+
+/obj/machinery/sparker/directional/east
+	dir = WEST
+	pixel_x = 26
+
+/obj/machinery/sparker/directional/west
+	dir = EAST
+	pixel_x = -26
+
 /obj/machinery/sparker/toxmix
 	id = INCINERATOR_TOXMIX_IGNITER
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -9,6 +9,22 @@
 	/// instead of the switch's location.
 	var/area/area = null
 
+/obj/machinery/light_switch/directional/north
+	dir = SOUTH
+	pixel_y = 26
+
+/obj/machinery/light_switch/directional/south
+	dir = NORTH
+	pixel_y = -26
+
+/obj/machinery/light_switch/directional/east
+	dir = WEST
+	pixel_x = 26
+
+/obj/machinery/light_switch/directional/west
+	dir = EAST
+	pixel_x = -26
+
 /obj/machinery/light_switch/Initialize()
 	. = ..()
 	if(istext(area))

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -69,6 +69,22 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 	max_integrity = 300
 	armor = list(MELEE = 70, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 0, BIO = 0, RAD = 0, FIRE = 90, ACID = 90)
 
+/obj/machinery/requests_console/directional/north
+	dir = SOUTH
+	pixel_y = 30
+
+/obj/machinery/requests_console/directional/south
+	dir = NORTH
+	pixel_y = -30
+
+/obj/machinery/requests_console/directional/east
+	dir = WEST
+	pixel_x = 30
+
+/obj/machinery/requests_console/directional/west
+	dir = EAST
+	pixel_x = -30
+
 /obj/machinery/requests_console/update_icon_state()
 	if(machine_stat & NOPOWER)
 		set_light(0)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -158,6 +158,22 @@
 	var/friendc = FALSE      // track if Friend Computer mode
 	var/last_picture  // For when Friend Computer mode is undone
 
+/obj/machinery/status_display/evac/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/status_display/evac/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/status_display/evac/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/status_display/evac/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/machinery/status_display/evac/Initialize()
 	. = ..()
 	// register for radio system
@@ -322,6 +338,22 @@
 		AI_EMOTION_BLUE_GLOW = "ai_sal",
 		AI_EMOTION_RED_GLOW = "ai_hal",
 	)
+
+/obj/machinery/status_display/ai/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/status_display/ai/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/status_display/ai/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/status_display/ai/directional/west
+	dir = EAST
+	pixel_x = -32
 
 /obj/machinery/status_display/ai/Initialize()
 	. = ..()

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -170,6 +170,22 @@
 	anchored = TRUE
 	density = FALSE
 
+/obj/item/storage/secure/safe/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/item/storage/secure/safe/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/item/storage/secure/safe/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/item/storage/secure/safe/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/item/storage/secure/safe/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -10,6 +10,22 @@
 	var/obj/item/extinguisher/stored_extinguisher
 	var/opened = FALSE
 
+/obj/structure/extinguisher_cabinet/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/structure/extinguisher_cabinet/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/structure/extinguisher_cabinet/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/structure/extinguisher_cabinet/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/structure/extinguisher_cabinet/Initialize(mapload, ndir, building)
 	. = ..()
 	if(building)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -12,6 +12,22 @@
 	var/open = FALSE
 	var/obj/item/fireaxe/fireaxe
 
+/obj/structure/fireaxecabinet/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/structure/fireaxecabinet/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/structure/fireaxecabinet/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/structure/fireaxecabinet/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/structure/fireaxecabinet/Initialize()
 	. = ..()
 	fireaxe = new

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -9,6 +9,22 @@
 	max_integrity = 200
 	integrity_failure = 0.5
 
+/obj/structure/mirror/directional/north
+	dir = SOUTH
+	pixel_y = 28
+
+/obj/structure/mirror/directional/south
+	dir = NORTH
+	pixel_y = -28
+
+/obj/structure/mirror/directional/east
+	dir = WEST
+	pixel_x = 28
+
+/obj/structure/mirror/directional/west
+	dir = EAST
+	pixel_x = -28
+
 /obj/structure/mirror/Initialize(mapload)
 	. = ..()
 	if(icon_state == "mirror_broke" && !broken)

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -11,6 +11,22 @@
 	/// Current number of a pinned notices
 	var/notices = 0
 
+/obj/structure/noticeboard/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/structure/noticeboard/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/structure/noticeboard/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/structure/noticeboard/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/structure/noticeboard/Initialize(mapload)
 	. = ..()
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -156,6 +156,22 @@
 	var/exposed = 0 // can you currently put an item inside
 	var/obj/item/hiddenitem = null // what's in the urinal
 
+/obj/structure/urinal/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/structure/urinal/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/structure/urinal/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/structure/urinal/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/structure/urinal/Initialize()
 	. = ..()
 	hiddenitem = new /obj/item/food/urinalcake

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -31,6 +31,22 @@
 	/// If blind drop option is available
 	var/blind_drop_ready = TRUE
 
+/obj/machinery/computer/auxiliary_base/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/computer/auxiliary_base/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/computer/auxiliary_base/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/computer/auxiliary_base/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/machinery/computer/auxiliary_base/Initialize()
 	. = ..()
 	AddComponent(/datum/component/gps, "NT_AUX")

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -21,6 +21,22 @@
 	var/list/ticket_holders = list()
 	var/list/obj/item/ticket_machine_ticket/tickets = list()
 
+/obj/machinery/ticket_machine/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/ticket_machine/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/ticket_machine/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/ticket_machine/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/machinery/ticket_machine/multitool_act(mob/living/user, obj/item/I)
 	if(!multitool_check_buffer(user, I)) //make sure it has a data buffer
 		return

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -987,5 +987,241 @@
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"
 
+// -------- Directional presets
+// The directions are backwards on the lights we have now
+/obj/machinery/light/directional/north
+	dir = NORTH
+
+/obj/machinery/light/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/directional/east
+	dir = EAST
+
+/obj/machinery/light/directional/west
+	dir = WEST
+
+// ---- Broken tube
+/obj/machinery/light/broken/directional/north
+	dir = NORTH
+
+/obj/machinery/light/broken/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/broken/directional/east
+	dir = EAST
+
+/obj/machinery/light/broken/directional/west
+	dir = WEST
+
+// ---- Tube construct
+/obj/structure/light_construct/directional/north
+	dir = NORTH
+
+/obj/structure/light_construct/directional/south
+	dir = SOUTH
+
+/obj/structure/light_construct/directional/east
+	dir = EAST
+
+/obj/structure/light_construct/directional/west
+	dir = WEST
+
+// ---- Tube frames
+/obj/machinery/light/built/directional/north
+	dir = NORTH
+
+/obj/machinery/light/built/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/built/directional/east
+	dir = EAST
+
+/obj/machinery/light/built/directional/west
+	dir = WEST
+
+// ---- No nightlight tubes
+/obj/machinery/light/no_nightlight/directional/north
+	dir = NORTH
+
+/obj/machinery/light/no_nightlight/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/no_nightlight/directional/east
+	dir = EAST
+
+/obj/machinery/light/no_nightlight/directional/west
+	dir = WEST
+
+// ---- Warm light tubes
+/obj/machinery/light/warm/directional/north
+	dir = NORTH
+
+/obj/machinery/light/warm/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/warm/directional/east
+	dir = EAST
+
+/obj/machinery/light/warm/directional/west
+	dir = WEST
+
+// ---- No nightlight warm light tubes
+/obj/machinery/light/warm/no_nightlight/directional/north
+	dir = NORTH
+
+/obj/machinery/light/warm/no_nightlight/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/warm/no_nightlight/directional/east
+	dir = EAST
+
+/obj/machinery/light/warm/no_nightlight/directional/west
+	dir = WEST
+
+// ---- Cold light tubes
+/obj/machinery/light/cold/directional/north
+	dir = NORTH
+
+/obj/machinery/light/cold/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/cold/directional/east
+	dir = EAST
+
+/obj/machinery/light/cold/directional/west
+	dir = WEST
+
+// ---- No nightlight cold light tubes
+/obj/machinery/light/cold/no_nightlight/directional/north
+	dir = NORTH
+
+/obj/machinery/light/cold/no_nightlight/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/cold/no_nightlight/directional/east
+	dir = EAST
+
+/obj/machinery/light/cold/no_nightlight/directional/west
+	dir = WEST
+
+// ---- Red tubes
+/obj/machinery/light/red/directional/north
+	dir = NORTH
+
+/obj/machinery/light/red/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/red/directional/east
+	dir = EAST
+
+/obj/machinery/light/red/directional/west
+	dir = WEST
+
+// ---- Blacklight tubes
+/obj/machinery/light/blacklight/directional/north
+	dir = NORTH
+
+/obj/machinery/light/blacklight/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/blacklight/directional/east
+	dir = EAST
+
+/obj/machinery/light/blacklight/directional/west
+	dir = WEST
+
+// ---- Dim tubes
+/obj/machinery/light/dim/directional/north
+	dir = NORTH
+
+/obj/machinery/light/dim/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/dim/directional/east
+	dir = EAST
+
+/obj/machinery/light/dim/directional/west
+	dir = WEST
+
+
+// -------- Bulb lights
+/obj/machinery/light/small/directional/north
+	dir = NORTH
+
+/obj/machinery/light/small/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/small/directional/east
+	dir = EAST
+
+/obj/machinery/light/small/directional/west
+	dir = WEST
+
+// ---- Bulb construct
+/obj/structure/light_construct/small/directional/north
+	dir = NORTH
+
+/obj/structure/light_construct/small/directional/south
+	dir = SOUTH
+
+/obj/structure/light_construct/small/directional/east
+	dir = EAST
+
+/obj/structure/light_construct/small/directional/west
+	dir = WEST
+
+// ---- Bulb frames
+/obj/machinery/light/small/built/directional/north
+	dir = NORTH
+
+/obj/machinery/light/small/built/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/small/built/directional/east
+	dir = EAST
+
+/obj/machinery/light/small/built/directional/west
+	dir = WEST
+
+// ---- Broken bulbs
+/obj/machinery/light/small/broken/directional/north
+	dir = NORTH
+
+/obj/machinery/light/small/broken/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/small/broken/directional/east
+	dir = EAST
+
+/obj/machinery/light/small/broken/directional/west
+	dir = WEST
+
+// ---- Red bulbs
+/obj/machinery/light/small/red/directional/north
+	dir = NORTH
+
+/obj/machinery/light/small/red/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/small/red/directional/east
+	dir = EAST
+
+/obj/machinery/light/small/red/directional/west
+	dir = WEST
+
+// ---- Blacklight bulbs
+/obj/machinery/light/small/blacklight/directional/north
+	dir = NORTH
+
+/obj/machinery/light/small/blacklight/directional/south
+	dir = SOUTH
+
+/obj/machinery/light/small/blacklight/directional/east
+	dir = EAST
+
+/obj/machinery/light/small/blacklight/directional/west
+	dir = WEST
+
 #undef LIGHT_DRAIN_TIME
 #undef LIGHT_POWER_GAIN

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -150,6 +150,22 @@
 	density = FALSE
 	reagent_id = /datum/reagent/consumable/condensedcapsaicin
 
+/obj/structure/reagent_dispensers/peppertank/directional/north
+	dir = SOUTH
+	pixel_y = 30
+
+/obj/structure/reagent_dispensers/peppertank/directional/south
+	dir = NORTH
+	pixel_y = -30
+
+/obj/structure/reagent_dispensers/peppertank/directional/east
+	dir = WEST
+	pixel_x = 30
+
+/obj/structure/reagent_dispensers/peppertank/directional/west
+	dir = EAST
+	pixel_x = -30
+
 /obj/structure/reagent_dispensers/peppertank/Initialize()
 	. = ..()
 	if(prob(1))
@@ -206,6 +222,21 @@
 	density = FALSE
 	reagent_id = /datum/reagent/consumable/virus_food
 
+/obj/structure/reagent_dispensers/virusfood/directional/north
+	dir = SOUTH
+	pixel_y = 30
+
+/obj/structure/reagent_dispensers/virusfood/directional/south
+	dir = NORTH
+	pixel_y = -30
+
+/obj/structure/reagent_dispensers/virusfood/directional/east
+	dir = WEST
+	pixel_x = 30
+
+/obj/structure/reagent_dispensers/virusfood/directional/west
+	dir = EAST
+	pixel_x = -30
 
 /obj/structure/reagent_dispensers/cooking_oil
 	name = "vat of cooking oil"

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -22,6 +22,22 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	var/mob/triggerer = null
 	var/waiting = FALSE
 
+/obj/machinery/keycard_auth/directional/north
+	dir = SOUTH
+	pixel_y = 26
+
+/obj/machinery/keycard_auth/directional/south
+	dir = NORTH
+	pixel_y = -26
+
+/obj/machinery/keycard_auth/directional/east
+	dir = WEST
+	pixel_x = 26
+
+/obj/machinery/keycard_auth/directional/west
+	dir = EAST
+	pixel_x = -26
+
 /obj/machinery/keycard_auth/Initialize()
 	. = ..()
 	ev = GLOB.keycard_events.addEvent("triggerEvent", CALLBACK(src, .proc/triggerEvent))

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -23,6 +23,22 @@
 	tiltable = FALSE
 	light_mask = "wallmed-light-mask"
 
+/obj/machinery/vending/wallmed/directional/north
+	dir = SOUTH
+	pixel_y = 32
+
+/obj/machinery/vending/wallmed/directional/south
+	dir = NORTH
+	pixel_y = -32
+
+/obj/machinery/vending/wallmed/directional/east
+	dir = WEST
+	pixel_x = 32
+
+/obj/machinery/vending/wallmed/directional/west
+	dir = EAST
+	pixel_x = -32
+
 /obj/item/vending_refill/wallmed
 	machine_name = "NanoMed"
 	icon_state = "refill_medical"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Port of TG #58809

If kirie or someone else dosent like it you can close it.

Adds directional variants to:

- pepper spray refills
- virus food dispensers
- wall-mounted flashes
- wall-mounted igniters (sparkers)
- defib mounts
- door buttons
- notice boards
- urinals
- wall safes
- light switches
- wall nanomeds
- fireaxe cabinets
- request consoles
- bounty boards
- mirrors
- entertainment monitors
- aux base monitor
- ticket machines
- tube lights
- small lights
- AI and evac screens

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Reduces map file sizes, easier to use when mapping, helps when porting map things from tg, skyrat, and whatever other server has these.
