### PR TITLE
Removes Health Analyzers

### DIFF
--- a/ModularBungalow/xenoarch/xenoarch_reward.dm
+++ b/ModularBungalow/xenoarch/xenoarch_reward.dm
@@ -10,7 +10,7 @@ GLOBAL_LIST_INIT(tier1_reward, list(
 GLOBAL_LIST_INIT(tier2_reward, list(
 	/obj/item/xenoarch/broken_item/tech = 1,
 	/obj/item/xenoarch/broken_item/plant = 1,
-	/obj/item/xenoarch/useless_relic = 5,
+	/obj/item/xenoarch/useless_relic = 2,
 ))
 
 GLOBAL_LIST_INIT(tier3_reward, list(

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2443,6 +2443,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "agO" = (
@@ -19720,7 +19721,8 @@
 	dir = 4
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/healthanalyzer,
+/obj/item/healthanalyzer/chem,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bhh" = (
@@ -21371,12 +21373,12 @@
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blF" = (
@@ -26330,10 +26332,10 @@
 "bAM" = (
 /obj/structure/table,
 /obj/item/analyzer,
-/obj/item/healthanalyzer,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plating,
 /area/storage/tech)
 "bAR" = (
@@ -32927,7 +32929,6 @@
 	name = "Virology Requests Console";
 	pixel_x = -32
 	},
-/obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/light{
 	dir = 8
@@ -32936,6 +32937,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
+/obj/item/healthanalyzer/viro,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bWg" = (
@@ -43637,7 +43639,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/clothing/neck/stethoscope,
+/obj/item/healthanalyzer/wound{
+	pixel_y = 5
+	},
+/obj/item/healthanalyzer/chem,
+/obj/item/healthanalyzer/paramed{
+	pixel_y = -6
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "fWv" = (

--- a/_maps/map_files/CasioStation/Casiostation.dmm
+++ b/_maps/map_files/CasioStation/Casiostation.dmm
@@ -13424,15 +13424,6 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"lgG" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/firstaid/emergency{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/emergency,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "lhd" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/dark/visible/layer5,
@@ -22335,6 +22326,10 @@
 /area/chapel)
 "syH" = (
 /obj/structure/table,
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/wound{
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
 "syT" = (
@@ -55968,7 +55963,7 @@ itG
 jcq
 jEE
 ktO
-lgG
+lja
 ktO
 ktO
 nre

--- a/_maps/map_files/Fermistation/Fermistation.dmm
+++ b/_maps/map_files/Fermistation/Fermistation.dmm
@@ -2389,16 +2389,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"aWJ" = (
-/obj/machinery/clonepod,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "aWV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23047,10 +23037,10 @@
 "izi" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/effect/turf_decal/trimline/green/filled/line,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "izt" = (
@@ -24218,15 +24208,15 @@
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "iYv" = (
@@ -38728,12 +38718,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"nYI" = (
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "nYP" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -40137,11 +40121,12 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
-/obj/item/healthanalyzer,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/chem,
 /turf/open/floor/plastic,
 /area/security/brig)
 "oyt" = (
@@ -47642,11 +47627,9 @@
 /area/engine/atmos)
 "qTy" = (
 /obj/structure/closet/secure_closet/chief_medical,
-/obj/item/clothing/head/beret/cmo,
 /obj/item/shears,
 /obj/item/clothing/head/nursehat,
 /obj/machinery/light,
-/obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "qTR" = (
@@ -60595,7 +60578,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "vgU" = (
-/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "vgX" = (
@@ -100789,8 +100771,8 @@ xkk
 xkk
 xkk
 iqG
-aWJ
-nYI
+tCW
+vgU
 vgU
 shf
 qnz
@@ -108506,8 +108488,8 @@ aMx
 blo
 lWi
 viW
-xmV
-xmV
+viW
+viW
 viW
 kiq
 vCD

--- a/_maps/map_files/GalaxyStation/Galaxystation.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation.dmm
@@ -1420,10 +1420,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"acU" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
 "acV" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -5165,11 +5161,11 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/light,
 /obj/structure/table,
-/obj/item/healthanalyzer,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -3;
 	pixel_y = 2
 	},
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ajw" = (
@@ -42883,10 +42879,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aaa
 aaa
 aaa
@@ -43140,10 +43136,10 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 iIV
 xlf
-acU
+aHv
 aaa
 aaa
 aaa
@@ -43397,10 +43393,10 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 aEh
 aCL
-acU
+aHv
 aaa
 aaa
 aaa
@@ -43654,10 +43650,10 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 jAR
 pji
-acU
+aHv
 aaa
 aaa
 aaa
@@ -44676,10 +44672,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aga
 aaa
 bbh
@@ -44933,7 +44929,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 jyR
 arV
 lZk
@@ -45190,10 +45186,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aga
 aaa
 bbh
@@ -45447,7 +45443,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 cNm
 avV
 lZk
@@ -45704,10 +45700,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aga
 aaa
 bbh
@@ -45961,7 +45957,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 wdd
 aWJ
 qjO
@@ -46475,7 +46471,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 cZj
 aUB
 lZk
@@ -46732,10 +46728,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aga
 nES
 xBA
@@ -46989,7 +46985,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 mWY
 aRy
 tys
@@ -47246,10 +47242,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aga
 nES
 mvI
@@ -47503,7 +47499,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 oji
 ave
 lsq
@@ -47760,7 +47756,7 @@ aaa
 aaa
 aaa
 aaa
-acU
+aHv
 sNG
 aPD
 lsq
@@ -48017,10 +48013,10 @@ aaa
 aaa
 aaa
 aaa
-acU
-acU
-acU
-acU
+aHv
+aHv
+aHv
+aHv
 aga
 aga
 bgS

--- a/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
+++ b/_maps/map_files/GalaxyStation/Galaxystation_LVL2.dmm
@@ -15764,7 +15764,6 @@
 "TG" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = -1
@@ -15789,6 +15788,7 @@
 	dir = 1;
 	pixel_y = 32
 	},
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "TJ" = (

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -4415,8 +4415,8 @@
 /obj/structure/table,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/electronics/airlock,
-/obj/item/healthanalyzer,
 /obj/item/assembly/flash/handheld,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plating,
 /area/storage/tech)
 "ajM" = (
@@ -8377,13 +8377,13 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/item/healthanalyzer,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/storage/firstaid/regular{
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "asj" = (
@@ -18368,10 +18368,10 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/obj/item/healthanalyzer,
 /obj/item/gps{
 	gpstag = "RD0"
 	},
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "cgz" = (
@@ -22076,7 +22076,6 @@
 "han" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/science,
 /obj/effect/turf_decal/tile/neutral,
@@ -22095,6 +22094,7 @@
 	name = "Virology Requests Console";
 	pixel_x = -32
 	},
+/obj/item/healthanalyzer/viro,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "hao" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -23459,7 +23459,6 @@
 "blr" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/healthanalyzer,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -24500,11 +24499,10 @@
 	pixel_y = 32
 	},
 /obj/structure/table,
-/obj/item/healthanalyzer{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/healthanalyzer,
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/chem,
+/obj/item/healthanalyzer/viro,
+/obj/item/healthanalyzer/wound,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "boK" = (
@@ -26274,9 +26272,6 @@
 	empty = 1;
 	name = "First-Aid (empty)"
 	},
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/structure/table,
@@ -26284,6 +26279,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bta" = (

--- a/_maps/map_files/RemoraStation/RemoraStation.dmm
+++ b/_maps/map_files/RemoraStation/RemoraStation.dmm
@@ -273,7 +273,9 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "aca" = (
-/obj/machinery/dna_scannernew,
+/obj/machinery/computer/scan_consolenew{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "acm" = (
@@ -726,9 +728,17 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "aiz" = (
-/obj/machinery/status_display,
-/turf/closed/wall,
-/area/library)
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "aiA" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -809,16 +819,16 @@
 "aiJ" = (
 /obj/structure/table/wood,
 /obj/machinery/camera/autoname,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "aiK" = (
 /obj/machinery/vending/games,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "aiL" = (
 /obj/machinery/computer/libraryconsole,
 /obj/structure/table/wood,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "aiO" = (
 /obj/machinery/light/small{
@@ -837,7 +847,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "aje" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
@@ -1174,8 +1184,10 @@
 /turf/open/floor/plating,
 /area/chapel)
 "akC" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
 /area/library)
 "akD" = (
 /obj/structure/table/wood,
@@ -1190,7 +1202,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -23
 	},
-/obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
 "akG" = (
@@ -3265,9 +3276,9 @@
 /turf/open/floor/plating,
 /area/medical/genetics)
 "aTg" = (
-/obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
 /obj/item/reagent_containers/glass/beaker,
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "aTP" = (
@@ -3316,7 +3327,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -5886,8 +5897,8 @@
 /turf/closed/wall/mineral/titanium,
 /area/science/mixing)
 "dkI" = (
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /obj/structure/cable,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dlC" = (
@@ -6082,7 +6093,7 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "dxP" = (
 /obj/structure/disposalpipe/segment{
@@ -8831,9 +8842,6 @@
 /area/science/server)
 "fFE" = (
 /obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/item/taperecorder,
 /obj/item/camera,
 /turf/open/floor/wood,
@@ -9081,18 +9089,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/medbay/central)
-"fUF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "fVd" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -9371,9 +9367,9 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "gnF" = (
-/mob/living/simple_animal/hostile/megafauna/chaos_marine,
 /obj/structure/chair/wood,
 /obj/effect/light_emitter,
+/mob/living/simple_animal/hostile/megafauna/gladiator,
 /turf/open/floor/carpet/black/airless,
 /area/asteroid/nearstation)
 "gnL" = (
@@ -11365,23 +11361,7 @@
 /turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
 "hVD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/effect/landmark/start/geneticist,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 26
-	},
+/obj/machinery/dna_scannernew,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "hWi" = (
@@ -12687,7 +12667,6 @@
 "jfy" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/surgical,
-/obj/item/healthanalyzer,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = -10;
@@ -12696,6 +12675,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "jgw" = (
@@ -13905,17 +13885,11 @@
 	pixel_x = -5;
 	pixel_y = -1
 	},
-/obj/item/healthanalyzer{
-	pixel_x = -3;
-	pixel_y = -4
-	},
-/obj/item/healthanalyzer{
-	pixel_x = 4;
-	pixel_y = 6
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/paramed,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "kmS" = (
@@ -15120,7 +15094,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "lpL" = (
 /obj/machinery/computer/nanite_cloud_controller,
@@ -15789,15 +15763,9 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "lWf" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/machinery/status_display,
+/turf/closed/wall,
+/area/library)
 "lXq" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -20392,6 +20360,10 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
+"pSM" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall,
+/area/library)
 "pSY" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -20644,20 +20616,20 @@
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = -5;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
+	},
+/obj/item/healthanalyzer/chem{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/healthanalyzer/paramed,
+/obj/item/healthanalyzer/wound{
+	pixel_x = 4;
+	pixel_y = -4
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
@@ -20670,6 +20642,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qch" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/library)
 "qcx" = (
 /turf/closed/wall,
 /area/maintenance/central)
@@ -21656,6 +21635,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"qUV" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/library)
 "qVy" = (
 /obj/structure/toilet{
 	dir = 8
@@ -22498,7 +22483,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rEL" = (
-/obj/structure/table/glass,
 /obj/item/storage/box/disks{
 	pixel_x = 1;
 	pixel_y = 5
@@ -22507,8 +22491,25 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
+"rEV" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Library"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/purple,
+/area/library)
 "rFa" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
@@ -23852,22 +23853,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sHY" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Library"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/library)
 "sIA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -25912,13 +25897,13 @@
 	dir = 8
 	},
 /obj/structure/closet,
-/obj/item/ai_module/core/full/asimov,
 /obj/item/ai_module/core/freeformcore,
 /obj/item/ai_module/core/full/hippocratic,
 /obj/item/ai_module/core/full/paladin,
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/effect/spawner/lootdrop/aimodule_harmful,
 /obj/effect/spawner/lootdrop/aimodule_neutral,
+/obj/item/ai_module/core/full/asimovpp,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hor)
 "unO" = (
@@ -26059,8 +26044,8 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "uxU" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "uyd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -26601,7 +26586,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/purple,
 /area/library)
 "uZA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -28006,6 +27991,10 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"wlR" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall,
+/area/library)
 "wnv" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet2";
@@ -28814,7 +28803,6 @@
 "wWH" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/science,
 /obj/machinery/requests_console{
@@ -28826,6 +28814,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/item/healthanalyzer/viro,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wXi" = (
@@ -29793,10 +29782,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/carpet/purple,
+/area/library)
 "xHX" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -30130,14 +30119,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes{
-	pixel_y = 3
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 2;
-	pixel_y = 5
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -65147,13 +65128,13 @@ niU
 esi
 oaf
 sXR
-sXR
-sXR
-sXR
-pIF
-sXR
-sXR
-biy
+lWf
+bSH
+bSH
+rEV
+wlR
+pSM
+hnM
 akY
 bZV
 bZV
@@ -65403,14 +65384,14 @@ pXu
 hEp
 ohM
 uUb
-aIU
-aIU
-aIU
-aIU
-xHz
 sXR
-dHQ
-biy
+bSH
+uxU
+qUV
+xHz
+ajp
+qch
+hnM
 jTq
 cgL
 cgL
@@ -65661,11 +65642,11 @@ hNv
 iQY
 rku
 rkR
-aiz
 bSH
-bSH
-sHY
 uxU
+qUV
+xHz
+ajp
 akC
 hnM
 mDz
@@ -65875,7 +65856,7 @@ aIo
 gxx
 nbl
 sJX
-abZ
+aiz
 kgr
 aTg
 aTd
@@ -65921,7 +65902,7 @@ sXR
 bSH
 aiI
 ajp
-fUF
+xHz
 fFE
 akD
 hnM
@@ -67168,12 +67149,12 @@ rwQ
 mMy
 vPB
 vPB
-hvF
 vPB
+hvF
 rwQ
 vPB
+vPB
 hvF
-lWf
 vPB
 dfE
 vPB
@@ -67423,13 +67404,13 @@ tqM
 sWS
 wrC
 wrC
+fju
+fju
+fju
 wrC
-wrC
-wrC
-wrC
-wrC
-wrC
-wrC
+fju
+fju
+fju
 wrC
 wrC
 wrC
@@ -68462,8 +68443,8 @@ tsW
 nhl
 pEb
 blE
-eRG
 dkI
+eRG
 eRG
 bHz
 eRG

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -11,7 +11,7 @@
 					/obj/item/reagent_containers/medigel/libital = 2,
 					/obj/item/reagent_containers/medigel/aiuri = 2,
 					/obj/item/reagent_containers/medigel/sterilizine = 1,
-					/obj/item/healthanalyzer/wound = 2,
+					/obj/item/healthanalyzer/paramed = 2,
 					/obj/item/stack/medical/bone_gel = 2)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 2,
 	                  /obj/item/reagent_containers/pill/morphine = 2,

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -13,7 +13,7 @@
 					/obj/item/stock_parts/cell/high = 12,
 					/obj/item/assembly/prox_sensor = 3,
 					/obj/item/assembly/signaler = 3,
-					/obj/item/healthanalyzer = 3,
+					/obj/item/healthanalyzer/paramed = 3,
 					/obj/item/scalpel = 2,
 					/obj/item/circular_saw = 2,
 					/obj/item/bonesetter = 2,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes all health analyzers from maps.
This is a long time coming

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They're not even available roundstart, now we're removing them from a lot of the maps.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: removed health analyzers from maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
