### PR TITLE
Fixes lawyer's office on casio

### DIFF
--- a/_maps/map_files/CasioStation/Casiostation.dmm
+++ b/_maps/map_files/CasioStation/Casiostation.dmm
@@ -1701,7 +1701,7 @@
 /area/crew_quarters/heads/captain/private)
 "bzJ" = (
 /obj/machinery/shower{
-	dir = 1
+	pixel_y = 15
 	},
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
@@ -2137,6 +2137,8 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/captain/bath,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/captain/private)
 "bUF" = (
@@ -8868,8 +8870,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/theatre)
 "hkJ" = (
-/obj/machinery/photocopier,
-/obj/machinery/camera/autoname,
+/obj/machinery/airalarm/directional/north,
+/obj/item/paper_bin,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/lawoffice)
 "hll" = (
@@ -19856,7 +19859,7 @@
 /obj/structure/closet,
 /obj/item/clothing/under/dress/blacktango,
 /obj/item/clothing/glasses/hud/health/syndicate,
-/obj/item/clothing/under/syndicate/suit,
+/obj/item/clothing/under/suit/helltaker/justice,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "qrA" = (
@@ -26871,9 +26874,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "wqZ" = (
-/obj/machinery/airalarm/directional/north,
-/obj/item/paper_bin,
-/obj/structure/table/wood,
+/obj/machinery/photocopier,
+/obj/machinery/camera/autoname,
 /turf/open/floor/wood,
 /area/lawoffice)
 "wrn" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves a desk on casio, also adds in the cap bathrobe
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
the lawyer drobe was inaccessible
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked lawyer office on casio
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
