### PR TITLE
Chemist is renamed Chemical Researcher

### DIFF
--- a/ModularBungalow/altjobtitles/alt_titles.dm
+++ b/ModularBungalow/altjobtitles/alt_titles.dm
@@ -72,7 +72,7 @@
 	senior_title = list("Genetic Engineer", "Freak of Genetics")
 
 /datum/job/chemre
-	alt_titles = list("Chemical Researcher", "Chemical Scientist")
+	alt_titles = list("Chemist", "Chemical Scientist")
 	senior_title = list("Chemical Engineer")
 
 //Medical
@@ -104,7 +104,7 @@
 /datum/job/officer
 	alt_titles = list("Security Guard", "Hazardous Device Technician", "NT Military Police")
 	senior_title = list("Man-at-Arms", "Sergeant Officer")
-	
+
 /datum/job/prisoner
 	alt_titles = list("Protected Custody")
 	senior_title = list("Detained Warcriminal")

--- a/ModularBungalow/clothing/neocoat.dm
+++ b/ModularBungalow/clothing/neocoat.dm
@@ -37,7 +37,7 @@
 
 //Chemical Researcher labcoat
 /obj/item/clothing/suit/neocoat/chemre
-	name = "Chemist's labcoat"
+	name = "Chemical Researcher's labcoat"
 	desc = "A beautiful purple and orange labcoat for the resarchers to wear. has outstanding acid resistance."
 	icon_state = "labcoat_chemre"
 	inhand_icon_state = "labcoat"

--- a/ModularBungalow/clothing/under.dm
+++ b/ModularBungalow/clothing/under.dm
@@ -94,8 +94,8 @@
 
 //Chemical Researcher Jumpsuit
 /obj/item/clothing/under/rank/research/chem
-	desc = "A tacky pick jumpsuit worn by the station's chemists."
-	name = "Chemist's jumpsuit"
+	desc = "A tacky pink jumpsuit worn by the station's chemists."
+	name = "Chemical Researcher's jumpsuit"
 	icon = 'ModularBungalow/clothing/icons/under.dmi'
 	worn_icon = 'ModularBungalow/clothing/worn/underw.dmi'
 	icon_state = "chemre"

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -51,7 +51,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		"Scientist" = 31,
 		"Roboticist" = 32,
 		"Geneticist" = 33,
-		"Chemist" = 34,
+		"Chemical Researcher" = 34,
 		// 40-49: Engineering
 		"Chief Engineer" = 40,
 		"Station Engineer" = 41,

--- a/code/game/objects/items/devices/PDA/PDA_types.dm
+++ b/code/game/objects/items/devices/PDA/PDA_types.dm
@@ -231,7 +231,7 @@
 	icon_state = "pda-genetics"
 
 /obj/item/pda/chemist
-	name = "chemist PDA"
+	name = "chemical researcher PDA"
 	default_cartridge = /obj/item/cartridge/chemistry
 	icon_state = "pda-chemre"
 

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -383,7 +383,7 @@
 /proc/get_all_jobs()
 	return list("Assistant", "Captain", "Head of Personnel", "Bartender", "Cook", "Botanist", "Quartermaster", "Cargo Technician",
 				"Shaft Miner", "Clown", "Mime", "Janitor", "Curator", "Lawyer", "Chaplain", "Chief Engineer", "Station Engineer",
-				"Deputy","Void Technician", "Chemist", "Secretary", //Bungalowstation edit
+				"Deputy","Void Technician", "Chemical Researcher", "Secretary", //Bungalowstation edit
 
 				"Atmospheric Technician", "Chief Medical Officer", "Medical Doctor", "Paramedic", "Pharmacist", "Geneticist", "Virologist", "Psychologist",
 				"Research Director", "Scientist", "Roboticist", "Head of Security", "Warden", "Detective", "Security Officer", "Prisoner")

--- a/code/modules/jobs/job_types/chemresearcher.dm
+++ b/code/modules/jobs/job_types/chemresearcher.dm
@@ -43,4 +43,4 @@
 //Spawn Point
 /obj/effect/landmark/start/chem
 	name = "Chemical Researcher"
-	icon_state = "Chemical Researcher"
+	icon_state = "Chemist"

--- a/code/modules/jobs/job_types/chemresearcher.dm
+++ b/code/modules/jobs/job_types/chemresearcher.dm
@@ -1,6 +1,6 @@
 /datum/job/chemre
-	title = "Chemist"
-	department_head = list("Research Director")
+	title = "Chemical Researcher"
+	department_head = list("Research Director", "Chief Medical Officer")
 	faction = "Station"
 	total_positions = 2
 	spawn_positions = 1
@@ -23,7 +23,7 @@
 	bounty_types = CIV_JOB_CHEM
 
 /datum/outfit/job/chemre
-	name = "Chemist"
+	name = "Chemical Researcher"
 	jobtype = /datum/job/chemre
 
 	glasses = /obj/item/clothing/glasses/science
@@ -42,5 +42,5 @@
 
 //Spawn Point
 /obj/effect/landmark/start/chem
-	name = "Chemist"
-	icon_state = "Chemist"
+	name = "Chemical Researcher"
+	icon_state = "Chemical Researcher"

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_INIT(science_positions, list(
 	"Scientist",
 	"Geneticist",
 	"Roboticist",
-	"Chemist"))
+	"Chemical Researcher"))
 
 
 GLOBAL_LIST_INIT(supply_positions, list(

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1938,7 +1938,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A heavily modified syringe gun which is capable of synthesizing its own chemical darts using input reagents. Can hold 100u of reagents."
 	item = /obj/item/gun/chem
 	cost = 12
-	restricted_roles = list("Pharmacist", "Chemist", "Chief Medical Officer", "Botanist")
+	restricted_roles = list("Pharmacist", "Chemical Researcher", "Chief Medical Officer", "Botanist")
 
 /datum/uplink_item/role_restricted/reverse_bear_trap
 	name = "Reverse Bear Trap"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
And Chemist is moved to an alt-title.

## About The Pull Request
Renames Chemist to Chemical Researcher
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I see, oftentimes, new players picking Chemist and not realizing it's a science job, entirely different from normal SS13.
This should fix that, partially. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: chemist is now chemical researcher
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
