### PR TITLE
Nerf/tweak Apostle

### DIFF
--- a/ModularBungalow/mobs/apostle.dm
+++ b/ModularBungalow/mobs/apostle.dm
@@ -1,10 +1,10 @@
 GLOBAL_LIST_EMPTY(apostles)
 
 /mob/living/simple_animal/hostile/megafauna/apostle
-	name = "apostle"
+	name = "white night"
 	desc = "The heavens' wrath. You might've fucked up real bad to summon one."
-	health = 800
-	maxHealth = 800
+	health = 1000
+	maxHealth = 1000
 	attack_verb_continuous = "purges"
 	attack_verb_simple = "purge"
 	attack_sound = 'sound/magic/mm_hit.ogg'
@@ -38,24 +38,19 @@ GLOBAL_LIST_EMPTY(apostles)
 	small_sprite_type = /datum/action/small_sprite/megafauna/tegu/angel
 	var/holy_revival_cooldown = 10 SECONDS
 	var/holy_revival_cooldown_base = 10 SECONDS
-	var/holy_revival_damage = 20 // Amount of damage OR heal, depending on target.
+	var/holy_revival_damage = 18 // Amount of damage OR heal, depending on target.
 	var/fire_field_cooldown = 20 SECONDS
 	var/fire_field_cooldown_base = 20 SECONDS
 	var/field_range = 4
 	var/scream_cooldown = 18 SECONDS
 	var/scream_cooldown_base = 18 SECONDS
-	var/scream_power = 25
-	var/apostle_cooldown = 20 SECONDS //Cooldown for conversion and revival of non-apostles.
-	var/apostle_cooldown_base = 20 SECONDS
-	var/blink_cooldown = 6 SECONDS
-	var/blink_cooldown_base = 6 SECONDS
+	var/scream_power = 20
+	var/blink_cooldown = 8 SECONDS
+	var/blink_cooldown_base = 8 SECONDS
 	var/apostle_num = 1 //Number of apostles. Used for revival and finale.
 	var/apostle_line
 	var/apostle_prev //Used for previous apostle's name, to reference in next line.
 	var/datum/action/innate/megafauna_attack/rapture/rapture_skill = new /datum/action/innate/megafauna_attack/rapture
-
-/mob/living/simple_animal/hostile/megafauna/apostle/Initialize()
-	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/apostle/ex_act(severity, target)
 	return //Resistant to explosions
@@ -63,7 +58,8 @@ GLOBAL_LIST_EMPTY(apostles)
 /mob/living/simple_animal/hostile/megafauna/apostle/bullet_act(obj/projectile/P)
 	if(istype(P, /obj/projectile/destabilizer)) // I hate you, miners.
 		visible_message("<span class='warning'>[src] absorbs [P]!</span>")
-		return BULLET_ACT_BLOCK
+		qdel(P)
+		return
 
 /datum/action/small_sprite/megafauna/tegu
 	small_icon = 'ModularTegustation/Teguicons/megafauna.dmi'
@@ -165,15 +161,13 @@ GLOBAL_LIST_EMPTY(apostles)
 		if(ishuman(i))
 			var/mob/living/carbon/human/H = i
 			if(!("apostle" in H.faction))
-				if(apostle_num < 13 && H.stat == DEAD && apostle_cooldown <= world.time && H.mind)
+				if(apostle_num < 13 && H.stat == DEAD && H.mind)
 					if(!H.client)
 						var/mob/dead/observer/ghost = H.get_ghost(TRUE, TRUE)
 						if(!ghost?.can_reenter_corpse) // If there is nobody able to control it - skip.
 							continue
 						else // If it can reenter - do it.
 							H.grab_ghost(force = TRUE)
-					apostle_cooldown = (world.time + apostle_cooldown_base)
-					// H.set_species(/datum/species/human, 1)
 					H.regenerate_limbs()
 					H.regenerate_organs()
 					H.dna.species.GiveSpeciesFlight(H)
@@ -235,10 +229,10 @@ GLOBAL_LIST_EMPTY(apostles)
 					armour_penetration += 5
 					melee_damage_lower += 2
 					melee_damage_upper += 2
-					maxHealth += 100
+					maxHealth += 50
 					health = maxHealth
 					holy_revival_damage += 2 // More damage and healing from AOE spell.
-					scream_power += 2 // Deafen them all. Destroy their ears.
+					scream_power += 1 // Deafen them all. Destroy their ears.
 					light_range += 1 // More light, because why not.
 				else
 					playsound(H.loc, 'sound/machines/clockcult/ark_damage.ogg', 50, TRUE, -1)
@@ -297,7 +291,7 @@ GLOBAL_LIST_EMPTY(apostles)
 		if("apostle" in C.faction)
 			continue
 		shake_camera(C, 1, 2)
-		C.soundbang_act(2, scream_power, 4)
+		C.soundbang_act(1, scream_power, 4)
 		C.jitteriness += (scream_power * 0.5)
 		C.do_jitter_animation(jitteriness)
 		C.blur_eyes(scream_power * 0.3, 0.6)

--- a/ModularBungalow/mobs/apostle_antag.dm
+++ b/ModularBungalow/mobs/apostle_antag.dm
@@ -21,6 +21,7 @@
 
 /datum/team/apostles
 	name = "Apostles"
+	var/victory_state = "none" // Updated on rapture and death
 
 /datum/antagonist/apostle/get_team()
 	return ap_team
@@ -54,6 +55,7 @@
 	var/datum/outfit/ApostleFit = new /datum/outfit/apostle
 	var/obj/item/wep_type
 	var/obj/effect/proc_holder/spell/spell_type = /obj/effect/proc_holder/spell/targeted/summonitem
+	ap_team.victory_state = "rapture"
 	switch(number)
 		if(1, 11) // Guardian
 			wep_type = /obj/item/nullrod/scythe/apostle/guardian
@@ -68,6 +70,9 @@
 			H.dropItemToGround(H.wear_mask)
 			spell_type = null
 			ApostleFit = /datum/outfit/apostle_heretic
+			to_chat(H, "<span class='userdanger'>Only now you realize the errors of your way! Seek to destroy the false prophet at any cost!</span>")
+			to_chat(H, "<span class='notice'>The bible shall grant you the powers to destroy them...</span>")
+			H.faction -= "apostle"
 	H.equipOutfit(ApostleFit)
 	if(wep_type)
 		var/obj/item/held = H.get_active_held_item()
@@ -87,6 +92,11 @@
 	H.visible_message("<span class='danger'>[H.real_name] briefly looks above...</span>", "<span class='userdanger'>You see the light above...</span>")
 	H.emote("scream")
 	H.Immobilize(200)
+	switch(ap_team.victory_state)
+		if("rapture")
+			ap_team.victory_state = "death_rapture"
+		else
+			ap_team.victory_state = "death"
 	addtimer(CALLBACK(src, .proc/soundd_in), (number * 6))
 
 /datum/antagonist/apostle/proc/soundd_in()
@@ -119,9 +129,18 @@
 			else
 				mod = "th"
 		parts += "[printplayer(A.owner.current.mind)]; The [A.number][mod] apostle."
-	if(members.len > 11)
-		parts += "<span class='greentext'>The rapture was successful!</span>"
-	else
-		parts += "<span class='redtext'>The apostles didn't manage to achieve rapture!</span>"
+	switch(victory_state)
+		if("rapture")
+			parts += "<span class='greentext big'>Victory!</span>"
+			parts += "<B>The rapture has been successful and White Night lives on.</B>"
+		if("death_rapture")
+			parts += "<span class='neutraltext big'>Draw!</span>"
+			parts += "<B>The rapture has been successful, but White Night has been defeated.</B>"
+		if("death")
+			parts += "<span class='redtext big'>Major Defeat!</span>"
+			parts += "<B>White Night didn't manage to achieve rapture and was defeated.</B>"
+		else
+			parts += "<span class='redtext big'>Defeat!</span>"
+			parts += "<B>The apostles didn't manage to achieve rapture.</B>"
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"

--- a/ModularTegustation/tegu_items/apostle_items.dm
+++ b/ModularTegustation/tegu_items/apostle_items.dm
@@ -71,6 +71,8 @@
 			user.jitteriness += (50)
 			user.do_jitter_animation(user.jitteriness)
 			apostle_use = FALSE
+			return
+	. = ..()
 
 /obj/item/clothing/suit/armor/apostle
 	name = "paradise lost"
@@ -80,11 +82,11 @@
 	item_flags = DROPDEL
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(MELEE = 70, BULLET = 50, LASER = 50, ENERGY = 80, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 95, WOUND = 15)
+	armor = list(MELEE = 55, BULLET = 40, LASER = 40, ENERGY = 80, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 95, WOUND = 15)
 	transparent_protection = HIDEGLOVES|HIDESUITSTORAGE|HIDEJUMPSUIT|HIDESHOES
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
-	slowdown = 0.4
+	slowdown = 0.3
 
 /obj/item/clothing/suit/armor/apostle/Initialize()
 	. = ..()
@@ -99,7 +101,7 @@
 	visor_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS
 	visor_flags_inv = HIDEFACIALHAIR
 	visor_flags_cover = MASKCOVERSMOUTH
-	armor = list(MELEE = 70, BULLET = 50, LASER = 50, ENERGY = 80, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 95, WOUND = 45) // Wound bonus so you can't remove their head.
+	armor = list(MELEE = 55, BULLET = 40, LASER = 40, ENERGY = 80, BOMB = 100, BIO = 100, RAD = 100, FIRE = 100, ACID = 95, WOUND = 45) // Wound bonus so you can't remove their head.
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	heat_protection = HEAD
 	body_parts_covered = HEAD
@@ -127,10 +129,10 @@
 	name = "holy scythe"
 	desc = "None shall harm us."
 	hitsound = 'ModularTegustation/Tegusounds/apostle/antagonist/scythe.ogg'
-	force = 34
+	force = 30
 	throwforce = 14 // Why are you throwing scythe anyway?
 	armour_penetration = 25
-	block_chance = 15
+	block_chance = 0
 	wound_bonus = 10
 	bare_wound_bonus = 20
 	sharpness = SHARP_EDGED
@@ -156,14 +158,14 @@
 /obj/item/nullrod/scythe/apostle/guardian
 	name = "guardian scythe"
 	desc = "The divine light will grant you protection."
-	force = 38
+	force = 33
 	throwforce = 18
-	armour_penetration = 40
-	block_chance = 30
+	armour_penetration = 35
+	block_chance = 20
 	var/recharge_time
 	var/recharge_base = 6 SECONDS
 	var/spell_radius = 1
-	var/spin_force = 75
+	var/spin_force = 66
 
 /obj/item/nullrod/scythe/apostle/guardian/attack_self(mob/living/carbon/user)
 	var/list/target_turfs = list()
@@ -201,13 +203,12 @@
 	desc = "A particle of light, obtained from the heart of the evil."
 	icon_state = "ap_scythe_light"
 	inhand_icon_state = "ap_scythe_light"
-	force = 45
-	throwforce = 24
-	armour_penetration = 60
-	block_chance = 40
+	force = 40
+	throwforce = 20
+	armour_penetration = 40
 	recharge_base = 5 SECONDS
 	spell_radius = 2
-	spin_force = 90
+	spin_force = 80
 	faction_needed = "hero" // Yep. A hero.
 	var/bound = FALSE // If it's true - nobody can gain the faction required to use it.
 
@@ -245,8 +246,11 @@
 		to_chat(user, "<span class='warning'>You are not ready to charge the staff yet.</span>")
 		return
 	charge_cooldown = (world.time + 5 SECONDS)
-	playsound(src, 'ModularTegustation/Tegusounds/apostle/antagonist/staff_charge.ogg', 100, 1)
-	new /obj/effect/temp_visual/dir_setting/curse/grasp_portal/fading(target)
+	playsound(src, 'ModularTegustation/Tegusounds/apostle/antagonist/staff_charge.ogg', 60, 1)
+	var/user_turf = get_turf(user)
+	var/target_turf = get_turf(target)
+	new /obj/effect/temp_visual/dir_setting/curse(user_turf, user.dir)
+	new /obj/effect/temp_visual/dir_setting/curse/grasp_portal/fading(target_turf, user.dir)
 	user.visible_message("<span class='warning'>[user] points [src] towards [target]!</span>", \
 	"<span class='warning'>We start channeling the power of [src].</span>", \
 	"<span class='hear'>You can hear an ominous buzzing.</span>")
@@ -259,7 +263,7 @@
 	projectile_type = /obj/projectile/magic/arcane_barrage/apostle
 
 /obj/projectile/magic/arcane_barrage/apostle
-	damage = 16
+	damage = 20
 	damage_type = BURN
 	armour_penetration = 25
 
@@ -319,7 +323,7 @@
 	recharge_time = (world.time + (recharge_time_base * 0.5)) // This one here to avoid spam
 	to_chat(user, "<span class='warning'>You change your stance and prepare to dash forward.</span>")
 	playsound(src, 'ModularTegustation/Tegusounds/apostle/antagonist/spear_charge.ogg', 100, 1)
-	if(!do_after(user, 36))
+	if(!do_after(user, 25))
 		return
 	recharge_time = (world.time + recharge_time_base) // The real cooldown
 	user.forceMove(final_T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Nerfs apostles' rapture armor melee, bullets and laser armor. Slowdown has been slightly reduced to compensate.
- Nerfed damage from apostles' rapture weaponry.
- Apostle heretic gets a proper message as to what they are supposed to do.
- Fixes the deafening scream ability. It doesn't go through ear protection anymore.
- Nerfs overall damage dealt by several abilities.
- Removed separate apostle cooldown in favor of keeping just the revival one.
- White Night has more(800 --> 1000) damage on spawn, but converting people grants you less health buffs.

## Why It's Good For The Game

Makes it less disgusting to fight against.

## Changelog
:cl:
fix: White Night(apostle megafauna)'s deafening scream can't ignore ear protection anymore.
tweak: Updated round-end screen for apostles. 4 states of victory/defeat!
balance: Most WN's abilities and attacks deal slightly less damage now.
balance: Apostles' rapture weapons and armor have been nerfed slightly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
