### PR TITLE
secretary's officer stuff

### DIFF
--- a/ModularBungalow/altjobtitles/alt_titles.dm
+++ b/ModularBungalow/altjobtitles/alt_titles.dm
@@ -174,7 +174,7 @@
 
 /datum/job/secretary
 	alt_titles = list("Lieutenant", "Union Representative", "Ambassador", "Diplomat")
-	senior_title = list("Junior Bridge Officer")
+	senior_title = list("Senior Bridge Officer")
 	ultra_senior_title = list("Sharon")
 
 /datum/job/hop

--- a/ModularBungalow/altjobtitles/outfits.dm
+++ b/ModularBungalow/altjobtitles/outfits.dm
@@ -139,7 +139,7 @@
 	head = /obj/item/clothing/head/beret/command
 	glasses = /obj/item/clothing/glasses/sunglasses
 	gloves = /obj/item/clothing/gloves/color/black
-	laceups = /obj/item/clothing/shoes/laceup
+	shoes = /obj/item/clothing/shoes/laceup
 	
 //Chief Medical Officer
 /datum/outfit/job/cmo/medicalprofessor

--- a/ModularBungalow/altjobtitles/outfits.dm
+++ b/ModularBungalow/altjobtitles/outfits.dm
@@ -126,13 +126,27 @@
 	backpack = /obj/item/storage/backpack/security
 	//the backpack is for style (also because det doesn't have officer armory access yet)
 
+//Secretary
+/datum/outfit/job/secretary/lieutenant
+	name = "Secretary (Lieutenant)"
+	accessory = /obj/item/clothing/accessory/medal/rank/nt/ltj
+	head = /obj/item/clothing/head/beret/black
+	glasses = /obj/item/clothing/glasses/sunglasses
+	
+/datum/outfit/job/secretary/seniorbridgeofficer
+	name = "Secretary (Senior Bridge Officer)"
+	accessory = /obj/item/clothing/accessory/medal/rank/nt/lt
+	head = /obj/item/clothing/head/beret/command
+	glasses = /obj/item/clothing/glasses/sunglasses
+	gloves = /obj/item/clothing/gloves/color/black
+	laceups = /obj/item/clothing/shoes/laceup
+	
 //Chief Medical Officer
 /datum/outfit/job/cmo/medicalprofessor
 	name = "Chief Medical Officer (Medical Professor)"
 	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck
 	suit = /obj/item/clothing/suit/toggle/labcoat/cmo
 	head = /obj/item/clothing/head/beret/cmo/ice
-
 
 /datum/outfit/job/cmo/seniormedicalofficer
 	name = "Chief Medical Officer (Senior Medical Officer)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the name for the secretary's senior title to be more accurate, as well as giving LT and SBO their own outfits. (Tested on local, worked fine)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More cool outfits is always nice, as well as a more accurate senior title name.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: outfits for both SBO (Senior Bridge Officer) and LT (Lieutenant)
tweak: secretary's senior title name
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![lt](https://user-images.githubusercontent.com/57843385/157906055-8fdbd520-6c5e-4ddf-85cd-845f481b6930.png)
![sbo](https://user-images.githubusercontent.com/57843385/157906056-8ed21f6c-652e-483c-9993-06c9824e950b.png)

