### PR TITLE
fixes platinium angel being gold core spawnable

### DIFF
--- a/ModularBungalow/mobs/megafauna/rockplanet/platinumangel/megafauna.dm
+++ b/ModularBungalow/mobs/megafauna/rockplanet/platinumangel/megafauna.dm
@@ -18,7 +18,7 @@
 	taunt_chance = 25
 	speed = 1
 	is_flying_animal = TRUE
-	gold_core_spawnable = NO_SPAWN
+	gold_core_spawnable = FALSE
 	stat_attack = HARD_CRIT
 	robust_searching = 1
 	loot = list(/obj/item/clothing/suit/space/hardsuit/platinum)

--- a/ModularBungalow/mobs/megafauna/rockplanet/platinumangel/megafauna.dm
+++ b/ModularBungalow/mobs/megafauna/rockplanet/platinumangel/megafauna.dm
@@ -18,6 +18,7 @@
 	taunt_chance = 25
 	speed = 1
 	is_flying_animal = TRUE
+	gold_core_spawnable = NO_SPAWN
 	stat_attack = HARD_CRIT
 	robust_searching = 1
 	loot = list(/obj/item/clothing/suit/space/hardsuit/platinum)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
removing the ability for players to spawn a invincible megafauna is good for the game right? 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: platinum angel is nolonger spawnable via gold xenobio extracts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
