### PR TITLE
New Implant & New loot for Tendrils

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -14,7 +14,7 @@
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
 
-	var/loot = rand(1,21)
+	var/loot = rand(1,22)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -68,6 +68,39 @@
 			new /obj/item/bedsheet/cult(src)
 		if(21)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
+		if(21)
+			new /obj/item/clothing/suit/hooded/techpriest/armor/initiate
+			new /obj/item/clothing/head/hooded/techpriest/armor/initiate
+			new /obj/item/mechandrites
+
+//Techpriest Gear for Explorer
+/obj/item/clothing/suit/hooded/techpriest/armor/initiate
+	name = "initiate techpriest's robes"
+	desc = "The whirrs of gears call to you initate"
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/organ/regenerative_core/legion, /obj/item/kitchen/knife/combat/bone, /obj/item/kitchen/knife/combat/survival, /obj/item/gun/energy)
+	armor = list("melee" = 30, "bullet" = 10, "laser" = 20, "energy" = 30, "bomb" = 30, "bio" = 60, "rad" = 30, "fire" = 60, "acid" = 60)
+	hoodtype = /obj/item/clothing/head/hooded/techpriest/armor/plate
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+	cold_protection = CHEST|GROIN|LEGS|ARMS
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+	heat_protection = CHEST|GROIN|LEGS|ARMS
+	resistance_flags = FIRE_PROOF
+
+/obj/item/clothing/suit/hooded/techpriest/armor/initiate/Initialize()
+	. = ..()
+	AddComponent(/datum/component/armor_plate)
+
+/obj/item/clothing/head/hooded/techpriest/armor/initiate
+	name = "initiate techpriest's hood"
+	desc = "Let the Omnissiah grant you wisdom"
+	armor = list("melee" = 30, "bullet" = 10, "laser" = 20, "energy" = 30, "bomb" = 30, "bio" = 60, "rad" = 30, "fire" = 60, "acid" = 60)
+	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
+	max_heat_protection_temperature = FIRE_HELM_MAX_TEMP_PROTECT
+
+/obj/item/clothing/head/hooded/techpriest/armor/initiate/Initialize()
+	. = ..()
+	AddComponent(/datum/component/armor_plate)
+
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc

--- a/code/modules/ruins/lavalandruin_code/techcult.dm
+++ b/code/modules/ruins/lavalandruin_code/techcult.dm
@@ -157,6 +157,7 @@
 	l_pocket = /obj/item/kitchen/knife/combat/survival
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	id = /obj/item/card/id/away/techcult
+	backpack_contents = list(/obj/item/mechandrites)
 
 /obj/effect/mob_spawn/human/techcult/leader
 	name = "Leader of the Machine Cult"
@@ -187,7 +188,7 @@
 	glasses = /obj/item/clothing/glasses/hud/diagnostic/night
 	r_hand = /obj/item/gun/energy/sniper
 	back = /obj/item/storage/backpack/cultpack
-	backpack_contents = list(/obj/item/storage/book/bible/omnissiah, /obj/item/book/granter/spell/omnissiah, /obj/item/organ/heart/cybernetic/tier4)
+	backpack_contents = list(/obj/item/storage/book/bible/omnissiah, /obj/item/book/granter/spell/omnissiah, /obj/item/organ/heart/cybernetic/tier4, /obj/item/mechandrites)
 
 /***************** Credo Omnissiah *****************/
 

--- a/code/modules/ruins/lavalandruin_code/techcult.dm
+++ b/code/modules/ruins/lavalandruin_code/techcult.dm
@@ -591,7 +591,7 @@
 	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
 	to_chat(user, "Your mechandrites whirr with life")
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, TRUE)
-	if(uses != 1)
+	if(uses == 1)
 		uses--
 	if(!uses)
 		desc = "[initial(desc)] Looks like it's been used up."

--- a/code/modules/ruins/lavalandruin_code/techcult.dm
+++ b/code/modules/ruins/lavalandruin_code/techcult.dm
@@ -580,9 +580,18 @@
 	desc = "An implanter for mechandrites, allowing a follower of the Omnissiah to gain newly found dexterity and handiness"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "autoimplanter"
-	var/oneuse = TRUE
+	var/uses = 1
 
 /obj/item/mechandrites/attack_self(mob/user)
+	if(!uses)
+		to_chat(user, "<span class='alert'>[src] has already been used. The tools are dull and won't reactivate.</span>")
+		return
 	var/limbs = user.held_items.len
 	user.change_number_of_hands(limbs+1)
+	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
 	to_chat(user, "Your mechandrites whirr with life")
+	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, TRUE)
+	if(uses != 1)
+		uses--
+	if(!uses)
+		desc = "[initial(desc)] Looks like it's been used up."

--- a/code/modules/ruins/lavalandruin_code/techcult.dm
+++ b/code/modules/ruins/lavalandruin_code/techcult.dm
@@ -572,3 +572,17 @@
 		reagent_names["[initial(reagent.name)] (Has Side-Effects)"] = reagent
 	else
 		reagent_names[initial(reagent.name)] = reagent
+
+//Mechandrites for the Mechanicus
+
+/obj/item/mechandrites
+	name = "\improper Mechandrite Implanter"
+	desc = "An implanter for mechandrites, allowing a follower of the Omnissiah to gain newly found dexterity and handiness"
+	icon = 'icons/obj/device.dmi'
+	icon_state = "autoimplanter"
+	var/oneuse = TRUE
+
+/obj/item/mechandrites/attack_self(mob/user)
+	var/limbs = user.held_items.len
+	user.change_number_of_hands(limbs+1)
+	to_chat(user, "Your mechandrites whirr with life")

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1741,6 +1741,19 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 16
 	surplus = 0
 
+/datum/uplink_item/device_tools/arm
+	name = "Additional Arm"
+	desc = "An additional arm, automatically added to your body upon purchase, allows you to use more items at once. Gained from the help of some sympathetic Tech priests"
+	item = /obj/item/melee/supermatter_sword //doesn't actually spawn a supermatter sword, but it needs an object to show up in the menu :^)
+	cost = 5
+	surplus = 0
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/device_tools/arm/spawn_item(spawn_item, mob/user)
+	var/limbs = user.held_items.len
+	user.change_number_of_hands(limbs+1)
+	to_chat(user, "You feel more dexterous")
+
 //Race-specific items
 /datum/uplink_item/race_restricted
 	category = "Species-Restricted"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I added a Mechandrite Implant and a version of the Tech-priest robes but without the holy requirement

Both of them would be placed together as loot for the Necropolis Tendril, and the Mechandrite is spawned alongside Techpriests inside their loadout and is within the Traitor (no Nukies) uplink with a pricing of 5 TC

Mechandrite is basically an extra hand, pretty nifty and works with the guns multi-wield wherein they fire all the guns at once in harm intent, but two-handed items or weapons cannot be used alongside the arm, as you would be unable to swap to the third hand once dual-wielded. Also implants can't go on the mechandrite as for now, sadly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
New item, new loot that's mild for miners so a miner buff(?), and a generally neat item
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added mechandrites
add: Added non-holy tech priest armored robes
tweak: adjusted the tendril a bit to account for mechandrites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
