### PR TITLE
Anarchy doesn't delete equipment

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -585,12 +585,6 @@
 				else
 					H.equip_to_slot_or_del(newuniform, ITEM_SLOT_ICLOTHING)
 
-				// Some stuff gets yeeted.
-				qdel(H.wear_suit)
-				qdel(H.head)
-				qdel(H.wear_mask)
-				qdel(H.shoes)
-
 				if(isplasmaman(H)) // So you don't get killed
 					var/obj/item/clothing/mask/newhead = new /obj/item/clothing/head/helmet/space/plasmaman/robotics/anarchy
 					newuniform = new /obj/item/clothing/under/plasmaman/robotics/anarchy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

"Anarch-communist" secret no longer deletes your equipment.

## Why It's Good For The Game

As funny as it is, some people were complaining that their precious armor or hat were being deleted.

## Changelog
:cl:
tweak: Anarcho-communist admin button no longer deletes your equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
