### PR TITLE
adds GPS and oreboxes to mining maps missing them

### DIFF
--- a/_maps/map_files/Mining/Asteroidbelt.dmm
+++ b/_maps/map_files/Mining/Asteroidbelt.dmm
@@ -529,7 +529,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/autolathe,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "kl" = (
@@ -1618,7 +1618,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/mine/lobby)
 "Iv" = (

--- a/_maps/map_files/Mining/Jungle.dmm
+++ b/_maps/map_files/Mining/Jungle.dmm
@@ -514,13 +514,9 @@
 /area/mine/living_quarters)
 "BE" = (
 /obj/structure/table,
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid{
-	pixel_x = 3
-	},
-/obj/item/storage/firstaid{
-	pixel_x = 5
-	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/wood,
 /area/mine/living_quarters)
@@ -781,7 +777,7 @@
 	dwidth = 3;
 	height = 10;
 	id = "mining_away";
-	name = "lavaland mine";
+	name = "jungle mine";
 	width = 7
 	},
 /turf/open/floor/plating/asteroid,
@@ -31374,7 +31370,7 @@ cB
 cB
 cB
 cB
-OI
+cB
 cB
 cB
 cB

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1221,10 +1221,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/storage/firstaid,
-/obj/item/storage/firstaid{
-	pixel_x = 3
-	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/mine/living_quarters)
 "dF" = (

--- a/_maps/map_files/Mining/Rockplanet.dmm
+++ b/_maps/map_files/Mining/Rockplanet.dmm
@@ -151,6 +151,13 @@
 /obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plating/rust,
 /area/mine/rockplanet_nanotrasen)
+"iR" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/mine/rockplanet_nanotrasen)
 "iW" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -193,10 +200,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/rockplanet)
-"lo" = (
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/mine/rockplanet_nanotrasen)
 "lr" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -324,7 +327,9 @@
 /area/rockplanet/surface/outdoors)
 "td" = (
 /obj/structure/table,
-/obj/item/storage/toolbox/electrical,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
 /turf/open/floor/plasteel,
 /area/mine/rockplanet_nanotrasen)
 "tq" = (
@@ -878,6 +883,13 @@
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel,
 /area/mine/rockplanet)
+"Ti" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel,
+/area/mine/rockplanet_nanotrasen)
 "TH" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/rust,
@@ -917,6 +929,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/mine/rockplanet)
+"VZ" = (
+/obj/machinery/telecomms/relay/preset/mining,
+/turf/open/floor/plasteel,
+/area/mine/rockplanet_nanotrasen)
 "Wf" = (
 /turf/open/floor/plating/rust,
 /area/mine/rockplanet_nanotrasen)
@@ -8465,7 +8481,7 @@ bt
 bt
 wW
 gS
-lo
+mv
 mv
 nJ
 mv
@@ -8721,8 +8737,8 @@ bt
 bt
 bt
 wW
-iW
-lo
+iR
+uc
 Wf
 wW
 td
@@ -8980,9 +8996,9 @@ bt
 wW
 zL
 lr
-uc
+VZ
 wW
-tq
+Ti
 tq
 Wf
 Wf

--- a/_maps/map_files/Mining/Rockplanet.dmm
+++ b/_maps/map_files/Mining/Rockplanet.dmm
@@ -420,6 +420,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
 /area/mine/rockplanet_nanotrasen)
 "yH" = (

--- a/_maps/map_files/Mining/Tidalmoon.dmm
+++ b/_maps/map_files/Mining/Tidalmoon.dmm
@@ -338,7 +338,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "fs" = (
@@ -1467,7 +1467,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "vu" = (

--- a/_maps/map_files/PackedStation/PackedStation.dmm
+++ b/_maps/map_files/PackedStation/PackedStation.dmm
@@ -15782,13 +15782,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"aOe" = (
-/obj/machinery/light_switch{
-	dir = 4;
-	pixel_x = 23
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
 "aOi" = (
 /obj/item/radio/intercom{
 	pixel_x = 25
@@ -16851,6 +16844,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "aWw" = (
@@ -19566,6 +19560,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/item/gps/mining,
+/obj/item/gps/mining,
+/obj/item/gps/mining,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "dNY" = (
@@ -20985,6 +20982,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "fEB" = (
@@ -33066,6 +33064,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "uyM" = (
@@ -63024,7 +63023,7 @@ amW
 any
 uSz
 uSz
-aOe
+uSz
 uwR
 aKv
 akf

--- a/_maps/map_files/TaliStation/TaliStation.dmm
+++ b/_maps/map_files/TaliStation/TaliStation.dmm
@@ -19767,7 +19767,7 @@
 	height = 10;
 	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/large;
+	roundstart_template = /datum/map_template/shuttle/mining/delta;
 	width = 7
 	},
 /turf/open/space/basic,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds GPS and tcomms to rockplanet
fixes the APC on rockplanet being connected to the SMES' input
adds oreboxes to tidal
adds a oxy can to asteroid belt
adds oreboxes and GPS to packed
also replaces some empty aidkits to full ones
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
🆑
add: adds GPS and tcomms to rockplanet
fix: fixes the APC on rockplanet being connected to the SMES' input
add: adds other misc stuff like oreboxes and GPS to maps missing them
/🆑
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
