### PR TITLE
Change "ambience" preference

### DIFF
--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -213,7 +213,7 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/settings/sound, toggle_instruments)()
 
 
 TOGGLE_CHECKBOX(/datum/verbs/menu/settings/sound, Toggle_Soundscape)()
-	set name = "Hear/Silence Ambience"
+	set name = "Hear/Silence Ambient Sounds"
 	set category = "Preferences"
 	set desc = "Hear Ambient Sound Effects"
 	usr.client.prefs.toggles ^= SOUND_AMBIENCE
@@ -223,7 +223,6 @@ TOGGLE_CHECKBOX(/datum/verbs/menu/settings/sound, Toggle_Soundscape)()
 	else
 		to_chat(usr, "You will no longer hear ambient sounds.")
 		usr.stop_sound_channel(CHANNEL_AMBIENCE)
-		usr.stop_sound_channel(CHANNEL_BUZZ)
 		usr.client.update_ambience_pref()
 	SSblackbox.record_feedback("nested tally", "preferences_verb", 1, list("Toggle Ambience", "[usr.client.prefs.toggles & SOUND_AMBIENCE ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 /datum/verbs/menu/settings/sound/Toggle_Soundscape/Get_checked(client/C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so the preference "Hear/Silence Ambience" is instead "Hear/Silence Ambient Sounds" and makes it so it doesn't stop ship ambience
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's kinda confusing if you see "silence ambience" when trying to turn off the ship rumble and it comes back on a bit later, so I think it saying "ambient sounds" is more accurate and less able to be confused by people. there's both "Hear/Silence Ambience" and "Hear/Silence Ship Ambience" and that may be confusing as well
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed name of "Hear/Silence Ambience" to "Hear/Silence Ambient Sounds"
del: removed "Hear/Silence Ambience" stopping ship rumble
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
