### PR TITLE
Removes the Axe from the asteroid base

### DIFF
--- a/_maps/map_files/Mining/Asteroidbelt.dmm
+++ b/_maps/map_files/Mining/Asteroidbelt.dmm
@@ -19,13 +19,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/production)
-"at" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
 "aA" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -98,7 +91,7 @@
 /area/mine/eva)
 "bO" = (
 /obj/machinery/door/airlock/wood{
-	id_tag = "miningdorm3";
+	id_tag = null;
 	name = "Cryoroom"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -639,20 +632,9 @@
 /turf/open/floor/plasteel/white,
 /area/mine/lobby)
 "nb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/mine/production)
-"ne" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/visible{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -929,7 +911,7 @@
 "se" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/mine/production)
 "su" = (
 /obj/effect/landmark/portal_exit{
@@ -1006,13 +988,7 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "uY" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine/o2,
 /area/mine/production)
 "va" = (
 /obj/structure/table/wood,
@@ -1086,10 +1062,8 @@
 /turf/open/indestructible/cult,
 /area/ruin/space/has_grav/powered)
 "wI" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/miner/oxygen,
+/turf/open/floor/engine/o2,
 /area/mine/production)
 "wO" = (
 /obj/structure/rack,
@@ -1230,15 +1204,10 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "AX" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	pixel_x = 30;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/engine/n2,
 /area/mine/production)
 "Bf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -1349,8 +1318,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -1807,16 +1776,12 @@
 /turf/open/floor/plasteel,
 /area/mine/lobby)
 "Mm" = (
-/obj/machinery/button/door{
-	id = "miningdorm3";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 25;
-	specialfunctions = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/mob_spawn/human/hermit/miningstation,
-/turf/open/floor/wood,
-/area/mine/lobby)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "MA" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -1944,10 +1909,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"Pd" = (
-/obj/structure/fireaxecabinet/directional/north,
-/turf/open/floor/plating,
-/area/mine/production)
 "PN" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -2023,10 +1984,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"QT" = (
-/obj/machinery/door/airlock/atmos/glass,
-/turf/open/floor/plasteel,
-/area/mine/production)
 "Rb" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
@@ -2152,9 +2109,7 @@
 /turf/open/floor/wood,
 /area/mine/cafeteria)
 "Uh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "UE" = (
@@ -2408,7 +2363,7 @@
 /area/mine/maintenance)
 "ZC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/mine/production)
 "ZD" = (
 /turf/open/genturf,
@@ -50244,7 +50199,7 @@ yG
 jX
 gW
 Xz
-Mm
+Om
 Om
 Om
 gW
@@ -50636,7 +50591,7 @@ ZR
 ZR
 ZR
 Ld
-Pd
+dg
 dg
 dg
 dg
@@ -51851,10 +51806,10 @@ om
 KQ
 bh
 Ld
-BH
-BH
-BH
-QT
+Mm
+WS
+WS
+WS
 Ld
 ZR
 ZR
@@ -52655,9 +52610,9 @@ Ey
 Eh
 tL
 Ld
-ne
 Uh
-at
+Uh
+Uh
 nb
 Ld
 ZR
@@ -53059,7 +53014,7 @@ tL
 Ld
 uY
 wI
-wI
+uY
 AX
 Ld
 ZR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the axe from the asteroid mining base, and gives them proper O2 tank
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Giving miners a fucking axe was an awful idea and honestly an oversight.
I wanted a fully functional mining station and went a little overboard.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed axe from the asteroid base.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
