### PR TITLE
Rockplanet Mob Rebalance, and Arlem Nerf

### DIFF
--- a/ModularBungalow/Mining/rockplanet.dm
+++ b/ModularBungalow/Mining/rockplanet.dm
@@ -52,16 +52,16 @@
 	open_turf_types = list(/turf/open/floor/plating/asteroid = 1)
 	closed_turf_types = list(/turf/closed/mineral/random/stationside/asteroid/rockplanet = 1)
 
-	mob_spawn_chance = 3
+	mob_spawn_chance = 4
 
 	mob_spawn_list = list(
-		/mob/living/simple_animal/hostile/hivebot = 30,
-		/mob/living/simple_animal/hostile/hivebot/strong = 5,
-		/mob/living/simple_animal/hostile/hivebot/range = 20,
-		/mob/living/simple_animal/hostile/hivebot/rapid = 10,
-		/mob/living/simple_animal/hostile/hivebot/mechanic = 20,
-		/mob/living/simple_animal/hostile/asteroid/goliath = 3,
-		/mob/living/simple_animal/hostile/asteroid/hivelord = 3)
+		/mob/living/simple_animal/hostile/hivebot = 5,
+		/mob/living/simple_animal/hostile/hivebot/strong = 1,
+		/mob/living/simple_animal/hostile/hivebot/range = 4,
+		/mob/living/simple_animal/hostile/hivebot/rapid = 2,
+		/mob/living/simple_animal/hostile/hivebot/mechanic = 3,
+		/mob/living/simple_animal/hostile/asteroid/goliath = 2,
+		/mob/living/simple_animal/hostile/asteroid/hivelord = 1)
 	flora_spawn_list = list(
 		/obj/structure/flora/rock/jungle = 2,
 		/obj/structure/flora/junglebush = 2,

--- a/ModularBungalow/mobs/megafauna/rockplanet/arlem/megafauna.dm
+++ b/ModularBungalow/mobs/megafauna/rockplanet/arlem/megafauna.dm
@@ -143,7 +143,7 @@
 		var/turf/endloc = get_turf(target)
 		if(!endloc)
 			break
-		var/obj/projectile/P = new /obj/projectile/beam/laser/sniper(startloc)
+		var/obj/projectile/P = new /obj/projectile/energy/taser(startloc)
 		P.preparePixelProjectile(endloc, startloc, null, rand(5))
 		P.firer = src
 		if(target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shifts around mob weights on rockplanet.
Also changes Arlem's bullets from hitscan to neotaser bullets
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Well, hivebots were 10x more likely to show up than goliaths. This fixes that a little.

Also Arlem would literally instakill you. Now they no longer do so. They just knock you over.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked rockplanet spawns.
balance: Arlem no longer instakills you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
