### PR TITLE
The Belt PR

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -8,6 +8,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/belt_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/belt_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_BULKY
 	attack_verb_continuous = list("whips", "lashes", "disciplines")
 	attack_verb_simple = list("whip", "lash", "discipline")
 	max_integrity = 300
@@ -130,6 +131,7 @@
 	name = "medical belt"
 	desc = "Can hold various medical equipment."
 	icon_state = "medical"
+	w_class = WEIGHT_CLASS_NORMAL
 	inhand_icon_state = "medical"
 	worn_icon_state = "medical"
 

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -83,11 +83,11 @@
 	name = "ERT Security - High Alert"
 
 	mask = /obj/item/clothing/mask/gas/sechailer/swat
-	belt = /obj/item/gun/energy/pulse/carbine/loyalpin
+	l_hand = /obj/item/gun/energy/pulse/carbine/loyalpin
+	belt = /obj/item/storage/belt/security/full
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
 		/obj/item/storage/box/handcuffs=1,\
-		/obj/item/melee/baton/loaded=1,\
-		/obj/item/storage/belt/security/full=1)
+		/obj/item/melee/baton/loaded=1)
 
 
 /datum/outfit/centcom/ert/medic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes all belts but the medical belt bulky.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Belts are just a better box, let's be honest. This makes them act like actual belts.
The Medical belt is the exception. The CMO actually has both a medical belt and a defib belt. 

Eventually I will make a special CMO belt with a different color and whatever.
Also, First Aid kits already hold basically everything a medical belt does and they are normal sized items. It's whatever.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Belts are now a bulky item.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
