### PR TITLE
Kills Mining Traitor

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -30,6 +30,28 @@ GLOBAL_LIST_INIT(slot2type, list("head" = /obj/item/clothing/head/changeling, "w
 		message_admins("RANDOM ALERT! Changeling gamemode's job restrictions were removed! Any role can become an antagonist this round!")
 		no_restrictions = TRUE
 
+
+	if(prob(80) && !no_restrictions)
+		restricted_jobs += "Shaft Miner"
+		message_admins("GAMEMODE ALERT! Miners cannot be antagonists this round!")
+
+		/*God I can actually config this but holy shit this is brutal.
+		Admins have been bitching at me for fucking ever to nerf miner antag.
+		I didn't really want to change much aside from minor things but they forced my hand.
+		I am NOT going to go through mining changing every single fucking value,
+		instead I will just make miner antag less rare.
+
+		Miner antag is boring as shit anyways, they just leave the station for like 50 minutes.
+		IF they come back they are a god and if they don't then you lose a traitor.
+		This isn't being removed, nor will it be confined to the usual no job restriction like above
+		Instead I'm cutting it back to 20% of what it was before.
+
+		Will redo later - Kitsunemitsu
+	*/
+
+	else
+		message_admins("GAMEMODE ALERT! Miners can be antagonists this round!")
+
 	if(CONFIG_GET(flag/protect_roles_from_antagonist) && !no_restrictions)
 		restricted_jobs += protected_jobs
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -34,6 +34,28 @@
 		message_admins("RANDOM ALERT! Traitor gamemode's job restrictions were removed! Any role can become an antagonist this round!")
 		no_restrictions = TRUE
 
+	if(prob(80) && !no_restrictions)
+		restricted_jobs += "Shaft Miner"
+		message_admins("GAMEMODE ALERT! Miners cannot be antagonists this round!")
+
+		/*God I can actually config this but holy shit this is brutal.
+		Admins have been bitching at me for fucking ever to nerf miner antag.
+		I didn't really want to change much aside from minor things but they forced my hand.
+		I am NOT going to go through mining changing every single fucking value,
+		instead I will just make miner antag less rare.
+
+		Miner antag is boring as shit anyways, they just leave the station for like 50 minutes.
+		IF they come back they are a god and if they don't then you lose a traitor.
+		This isn't being removed, nor will it be confined to the usual no job restriction like above
+		Instead I'm cutting it back to 20% of what it was before.
+
+		Will redo later - Kitsunemitsu
+	*/
+
+	else
+		message_admins("GAMEMODE ALERT! Miners can be antagonists this round!")
+
+
 	if(CONFIG_GET(flag/protect_roles_from_antagonist) && !no_restrictions)
 		restricted_jobs += protected_jobs
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the chance of mining traitor to 20%
This needs to be recoded to actually support other jobs like secretary who are okay as antag at 20% but when more than that are absolutely fucking stupid

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mining Traitors are honestly bad for the game.

Miner antag is boring as shit anyways, they just leave the station for like 50 minutes. 
IF they come back they are a god and if they don't then you lose a traitor.
This isn't being removed, nor will it be confined to the usual no job restriction like captain and HOS
Instead I'm cutting it back to 20% of what it was before.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Miners can only be traitors 20% of the time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
