### PR TITLE
Adds Pinlocked Trait to Miner Guns

### DIFF
--- a/ModularBungalow/bungalow_Weapons/Energy/sniper.dm
+++ b/ModularBungalow/bungalow_Weapons/Energy/sniper.dm
@@ -18,6 +18,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/sniper/weak)
 	pin = /obj/item/firing_pin/explorer
 	zoomable = FALSE
+	pinlocked = TRUE
 
 /obj/item/gun/energy/sniper/fallout/Initialize()
 	. = ..()

--- a/ModularBungalow/bungalow_Weapons/series/mining.dm
+++ b/ModularBungalow/bungalow_Weapons/series/mining.dm
@@ -9,11 +9,12 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun, /obj/item/ammo_casing/energy/kinetic)
 	w_class = WEIGHT_CLASS_SMALL
 	cell_type = /obj/item/stock_parts/cell/mini_egun
+	pinlocked = TRUE
 	selfcharge = 1
 
 //Miner's Laser Revolver
 /obj/item/gun/energy/e_gun/miner/revolver
-	name = "\improper E-326 Mining Revolve"
+	name = "\improper E-326 Mining Revolver"
 	desc = "A refined, powerful hitscan pistol."
 	icon = 'ModularBungalow/bungalow_Weapons/_icon/miningguns.dmi'
 	icon_state = "mining-revolver"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -43,6 +43,8 @@
 	var/weapon_weight = WEAPON_LIGHT
 	var/dual_wield_spread = 24			//additional spread when dual wielding
 
+	var/pinlocked = FALSE				//can you remove the pin?
+
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
 
@@ -76,6 +78,7 @@
 	var/zoom_out_amt = 0
 	var/datum/action/toggle_scope_zoom/azoom
 	var/pb_knockback = 0
+
 
 /obj/item/gun/Initialize()
 	. = ..()
@@ -443,15 +446,18 @@
 		return remove_gun_attachment(user, I, bayonet, "unfix")
 
 	else if(pin && user.is_holding(src))
-		user.visible_message("<span class='warning'>[user] attempts to remove [pin] from [src] with [I].</span>",
-		"<span class='notice'>You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)</span>", null, 3)
-		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))
-			if(!pin) //check to see if the pin is still there, or we can spam messages by clicking multiple times during the tool delay
-				return
-			user.visible_message("<span class='notice'>[pin] is pried out of [src] by [user], destroying the pin in the process.</span>",
-								"<span class='warning'>You pry [pin] out with [I], destroying the pin in the process.</span>", null, 3)
-			QDEL_NULL(pin)
-			return TRUE
+		if(pinlocked == FALSE)
+			user.visible_message("<span class='warning'>[user] attempts to remove [pin] from [src] with [I].</span>",
+			"<span class='notice'>You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)</span>", null, 3)
+			if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))
+				if(!pin) //check to see if the pin is still there, or we can spam messages by clicking multiple times during the tool delay
+					return
+				user.visible_message("<span class='notice'>[pin] is pried out of [src] by [user], destroying the pin in the process.</span>",
+									"<span class='warning'>You pry [pin] out with [I], destroying the pin in the process.</span>", null, 3)
+				QDEL_NULL(pin)
+				return TRUE
+		else
+			user.visible_message("<span class='notice'>You cannot remove the firing pin from this gun.</span>")
 
 /obj/item/gun/welder_act(mob/living/user, obj/item/I)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new gun variable to lock the miner guns to mining planets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
God, honestly this was planned for so fucking long.
These guns were NEVER designed to be used in the way they have before, where miners would mass buy them, and mass buy firing pins, and then fucking put regular pins in the mining guns.

This fixes it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new trait to where you cannot remove the firing pin from certain guns
balance: Miner guns cannot be used on station anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
