### PR TITLE
Curator's Whips and EMP'd Defibrillators Now Respect Blockchance

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -469,6 +469,11 @@
 		return
 	if(!req_defib && !combat)
 		return
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/H = M
+	if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
+		return
 	busy = TRUE
 	M.visible_message("<span class='danger'>[user] touches [M] with [src]!</span>", \
 			"<span class='userdanger'>[user] touches [M] with [src]!</span>")

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -605,10 +605,12 @@
 	if(!user) // There is no user holding a weapon; Probably thrown, so don't do all the funny stuff.
 		return
 
-	var/mob/living/carbon/H = target
+	var/mob/living/carbon/human/H = target
 	var/selected_bodypart_area = check_zone(user.zone_selected) // For stuff like eyes, mouth, etc.
 	var/target_limb = H.get_bodypart(selected_bodypart_area)
 	if(!target_limb) // Does this limb exist at all?
+		return
+	if(H.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK))
 		return
 	var/armor_v = H.getarmor(target_limb, type = "melee")
 	H.apply_damage(force, STAMINA, selected_bodypart_area, armor_v) // Regardless of limb, you get some stamina damage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Self-explanatory. Curator's whips and EMP'd defibrillators no longer bypass blockchance.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It doesn't quite make any logical sense that either of those completely penetrates weapon blocks, for instance, deswords or shields.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Your local curator's whip now has its abilities restrained to respect the corporeal realm, like riot shields and energy swords.
balance: EMP'd defibs respect block chance from items like riot shields and energy swords.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
